### PR TITLE
[ONB-1776] Config manager y output utilities

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@
 - `src/resources/` — resource registry + command factory
 - `src/lib/` — shared utilities (auth, config, output, errors)
 - `src/types.ts` — shared type definitions
-- `tests/` — Vitest tests
+- `src/**/__tests__/` — Vitest tests, colocated with source files
 
 ## Conventions
 - ESLint config uses `@antfu/eslint-config` (same as dashboard)

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -32,6 +32,7 @@ export default antfu(
       'ts/consistent-type-imports': 'error',
       'no-console': 'error',
       'node/prefer-global/process': 'off',
+      'test/consistent-test-it': ['error', { fn: 'test', withinDescribe: 'test' }],
     },
   },
 )

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/@antfu/eslint-config": {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,13 +1,13 @@
 import { execFileSync } from 'node:child_process'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, test } from 'vitest'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
-const CLI_PATH = resolve(__dirname, '..', 'dist', 'index.js')
+const CLI_PATH = resolve(__dirname, '..', '..', 'dist', 'index.js')
 
 describe('cli smoke test', () => {
-  it('shows version with --version flag', () => {
+  test('shows version with --version flag', () => {
     const output = execFileSync('node', [CLI_PATH, '--version'], {
       encoding: 'utf-8',
     }).trim()
@@ -15,7 +15,7 @@ describe('cli smoke test', () => {
     expect(output).toMatch(/^fintoc\/\d+\.\d+\.\d+ \w+ node-v\d+/)
   })
 
-  it('shows help with --help flag', () => {
+  test('shows help with --help flag', () => {
     const output = execFileSync('node', [CLI_PATH, '--help'], {
       encoding: 'utf-8',
     }).trim()

--- a/src/lib/__tests__/config.test.ts
+++ b/src/lib/__tests__/config.test.ts
@@ -1,0 +1,115 @@
+import type { FintocConfig } from '../../types.js'
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('node:fs')
+vi.mock('node:os', () => ({
+  homedir: () => '/mock-home',
+}))
+
+const { readConfig, writeConfig, clearConfig, CONFIG_DIR, CONFIG_PATH } =
+  await import('../config.js')
+
+const fs = await import('node:fs')
+
+const fsError = (code: string): NodeJS.ErrnoException => {
+  const err = new Error(code) as NodeJS.ErrnoException
+  err.code = code
+  return err
+}
+
+describe('config', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('has correct paths', () => {
+    expect(CONFIG_DIR).toBe('/mock-home/.fintoc')
+    expect(CONFIG_PATH).toBe('/mock-home/.fintoc/config.toml')
+  })
+
+  describe('readConfig', () => {
+    test('returns empty object when file does not exist', () => {
+      vi.mocked(fs.readFileSync).mockImplementation(() => {
+        throw fsError('ENOENT')
+      })
+
+      expect(readConfig()).toEqual({})
+    })
+
+    test('parses valid TOML', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue('secret_key = "sk_test_123"')
+
+      const config = readConfig()
+      expect(config).toEqual({ secret_key: 'sk_test_123' })
+    })
+
+    test('rethrows non-ENOENT errors', () => {
+      vi.mocked(fs.readFileSync).mockImplementation(() => {
+        throw fsError('EACCES')
+      })
+
+      expect(() => readConfig()).toThrow('EACCES')
+    })
+  })
+
+  describe('writeConfig', () => {
+    test('creates directory and writes file with correct permissions', () => {
+      vi.mocked(fs.mkdirSync).mockReturnValue(undefined)
+      vi.mocked(fs.writeFileSync).mockReturnValue(undefined)
+
+      const config: FintocConfig = { secret_key: 'sk_test_abc' }
+      writeConfig(config)
+
+      expect(fs.mkdirSync).toHaveBeenCalledWith('/mock-home/.fintoc', {
+        recursive: true,
+        mode: 0o700,
+      })
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/mock-home/.fintoc/config.toml',
+        expect.stringContaining('secret_key'),
+        { mode: 0o600 },
+      )
+    })
+
+    test('omits undefined values', () => {
+      vi.mocked(fs.mkdirSync).mockReturnValue(undefined)
+      vi.mocked(fs.writeFileSync).mockReturnValue(undefined)
+
+      writeConfig({ secret_key: 'sk_test_abc' })
+
+      const written = vi.mocked(fs.writeFileSync).mock.calls[0]![1] as string
+      expect(written).not.toContain('jws_private_key')
+    })
+  })
+
+  describe('clearConfig', () => {
+    test('deletes the config file', () => {
+      vi.mocked(fs.unlinkSync).mockReturnValue(undefined)
+
+      clearConfig()
+
+      expect(fs.unlinkSync).toHaveBeenCalledWith('/mock-home/.fintoc/config.toml')
+    })
+
+    test('is silent when file does not exist', () => {
+      vi.mocked(fs.unlinkSync).mockImplementation(() => {
+        throw fsError('ENOENT')
+      })
+
+      expect(() => clearConfig()).not.toThrow()
+    })
+
+    test('rethrows non-ENOENT errors', () => {
+      vi.mocked(fs.unlinkSync).mockImplementation(() => {
+        throw fsError('EACCES')
+      })
+
+      expect(() => clearConfig()).toThrow('EACCES')
+    })
+  })
+})

--- a/src/lib/__tests__/output.test.ts
+++ b/src/lib/__tests__/output.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import { error, log, success, warn } from '../output.js'
+
+describe('output', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('log writes to stdout', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    log('hello')
+    expect(spy).toHaveBeenCalledWith('hello')
+  })
+
+  test('success writes to stdout with ✔ prefix', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    success('done')
+    expect(spy).toHaveBeenCalledWith('✔ done')
+  })
+
+  test('error writes to stderr with ✘ prefix', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    error('fail')
+    expect(spy).toHaveBeenCalledWith('✘ fail')
+  })
+
+  test('warn writes to stderr with ⚠ prefix', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    warn('careful')
+    expect(spy).toHaveBeenCalledWith('⚠ careful')
+  })
+})

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,40 @@
+import type { FintocConfig } from '../types.js'
+import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+
+import { join } from 'node:path'
+
+import { parse, stringify } from 'smol-toml'
+
+export const CONFIG_DIR = join(homedir(), '.fintoc')
+export const CONFIG_PATH = join(CONFIG_DIR, 'config.toml')
+
+const isFileNotFound = (err: unknown): boolean =>
+  err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT'
+
+export const readConfig = (): FintocConfig => {
+  try {
+    const content = readFileSync(CONFIG_PATH, 'utf-8')
+    return parse(content) as FintocConfig
+  } catch (err) {
+    if (isFileNotFound(err)) return {}
+    throw err
+  }
+}
+
+export const writeConfig = (config: FintocConfig): void => {
+  mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 })
+
+  const clean = Object.fromEntries(Object.entries(config).filter(([, v]) => v !== undefined))
+
+  writeFileSync(CONFIG_PATH, stringify(clean), { mode: 0o600 })
+}
+
+export const clearConfig = (): void => {
+  try {
+    unlinkSync(CONFIG_PATH)
+  } catch (err) {
+    if (isFileNotFound(err)) return
+    throw err
+  }
+}

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -1,0 +1,17 @@
+/* eslint-disable no-console */
+
+export const log = (message: string): void => {
+  console.log(message)
+}
+
+export const success = (message: string): void => {
+  console.log(`✔ ${message}`)
+}
+
+export const error = (message: string): void => {
+  console.error(`✘ ${message}`)
+}
+
+export const warn = (message: string): void => {
+  console.error(`⚠ ${message}`)
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    include: ['tests/**/*.test.ts'],
+    include: ['src/**/__tests__/**/*.test.ts'],
   },
 })


### PR DESCRIPTION
## Cambios

- [x] `src/lib/output.ts` — Abstracción de output (`log`, `success`, `error`, `warn`) para centralizar console bajo regla `no-console`
- [x] `src/lib/config.ts` — Read/write `~/.fintoc/config.toml` con permisos 600
- [x] Migración de tests a `src/**/__tests__/` (consistencia con dashboard)

## Tests

Unitarios para output y config. Smoke test migrado a nueva estructura.

<sup>*Created with Claude Code `/create-pr` command*</sup>