### PR TITLE
[ONB-1780] Comando fintoc config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,70 @@
-# cli
-Fintoc CLI
+# Fintoc CLI
+
+Manage your Fintoc resources from the terminal.
+
+## Installation
+
+```bash
+npm install -g @fintoc/cli
+```
+
+Requires Node.js >= 22.
+
+## Quick start
+
+```bash
+# Authenticate with your API key
+fintoc login
+
+# Check your current configuration
+fintoc config
+
+# Remove stored credentials
+fintoc logout
+```
+
+## Authentication
+
+The CLI resolves your API key in this order:
+
+1. `--api-key` flag (inline, per-command)
+2. `FINTOC_SECRET_KEY` environment variable
+3. `~/.fintoc/config.toml` (saved via `fintoc login`)
+
+### `fintoc login`
+
+Interactive prompt to save your API key. Validates the key against the Fintoc API before storing it.
+
+```bash
+fintoc login
+# Or non-interactively:
+fintoc login --api-key sk_test_...
+```
+
+### `fintoc logout`
+
+Removes stored credentials from `~/.fintoc/config.toml`.
+
+### `fintoc config`
+
+Displays the active configuration: organization, mode (test/live), masked API key, and credential source.
+
+```
+$ fintoc config
+  Organization:  Acme Corp
+  Mode:          test
+  Secret key:    sk_test_····
+  API version:   2023-11-15
+  Config path:   ~/.fintoc/config.toml
+  Source:        config file
+```
+
+## Development
+
+```bash
+npm install
+npm run build        # Bundle to dist/
+npm run test         # Run tests
+npm run lint         # ESLint + Prettier
+npm run typecheck    # Type-check without emitting
+```

--- a/src/commands/__tests__/config.test.ts
+++ b/src/commands/__tests__/config.test.ts
@@ -1,0 +1,80 @@
+import { Command } from 'commander'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { resolveAuth, whoami } from '../../lib/auth.js'
+import { log, warn } from '../../lib/output.js'
+import { configCommand } from '../config.js'
+
+vi.mock('../../lib/auth.js', () => ({
+  resolveAuth: vi.fn(),
+  whoami: vi.fn(),
+  maskKey: vi.fn((k: string) => `${k.slice(0, 8)}····`),
+}))
+
+vi.mock('../../lib/config.js', () => ({
+  CONFIG_PATH: '/mock-home/.fintoc/config.toml',
+}))
+
+vi.mock('../../lib/output.js', () => ({
+  log: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+}))
+
+const createProgram = () => {
+  const program = new Command()
+  program.exitOverride()
+  configCommand(program)
+  return program
+}
+
+describe('config command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('shows full config when authenticated', async () => {
+    vi.mocked(resolveAuth).mockReturnValue({
+      secretKey: 'sk_test_abc123',
+      source: 'config',
+    })
+    vi.mocked(whoami).mockResolvedValue({
+      organizationName: 'Acme Corp',
+      mode: 'test',
+      apiVersion: '2023-03-15',
+    })
+
+    const program = createProgram()
+    await program.parseAsync(['config'], { from: 'user' })
+
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Acme Corp'))
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('test'))
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('config file'))
+  })
+
+  test('shows not authenticated when no key', async () => {
+    vi.mocked(resolveAuth).mockImplementation(() => {
+      throw new Error('No API key found')
+    })
+
+    const program = createProgram()
+    await program.parseAsync(['config'], { from: 'user' })
+
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Not authenticated'))
+  })
+
+  test('degrades gracefully when API is unreachable', async () => {
+    vi.mocked(resolveAuth).mockReturnValue({
+      secretKey: 'sk_test_abc123',
+      source: 'env',
+    })
+    vi.mocked(whoami).mockRejectedValue(new Error('Network error'))
+
+    const program = createProgram()
+    await program.parseAsync(['config'], { from: 'user' })
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Unable to reach Fintoc API'))
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('(unknown)'))
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('env var'))
+  })
+})

--- a/src/commands/__tests__/login.test.ts
+++ b/src/commands/__tests__/login.test.ts
@@ -50,9 +50,9 @@ describe('login command', () => {
   test('authenticates successfully with interactive prompt', async () => {
     vi.mocked(password).mockResolvedValue('sk_test_valid123')
     vi.mocked(whoami).mockResolvedValue({
-      organization_name: 'Acme Corp',
+      organizationName: 'Acme Corp',
       mode: 'test',
-      api_version: '2023-03-15',
+      apiVersion: '2023-03-15',
     })
 
     const program = createProgram()
@@ -69,9 +69,9 @@ describe('login command', () => {
     vi.mocked(password).mockResolvedValue('sk_test_new')
     vi.mocked(readConfig).mockReturnValue({ jws_private_key: '/path/to/key.pem' })
     vi.mocked(whoami).mockResolvedValue({
-      organization_name: 'Acme Corp',
+      organizationName: 'Acme Corp',
       mode: 'test',
-      api_version: '2023-03-15',
+      apiVersion: '2023-03-15',
     })
 
     const program = createProgram()
@@ -120,9 +120,9 @@ describe('login command', () => {
   test('authenticates with --api-key flag skipping prompt', async () => {
     vi.mocked(readConfig).mockReturnValue({})
     vi.mocked(whoami).mockResolvedValue({
-      organization_name: 'Acme Corp',
+      organizationName: 'Acme Corp',
       mode: 'test',
-      api_version: '2023-03-15',
+      apiVersion: '2023-03-15',
     })
 
     const program = createProgram()

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,0 +1,52 @@
+import type { Command } from 'commander'
+
+import { maskKey, resolveAuth, whoami } from '../lib/auth.js'
+import { CONFIG_PATH } from '../lib/config.js'
+import { log, warn } from '../lib/output.js'
+
+export const configCommand = (program: Command): void => {
+  program
+    .command('config')
+    .description('Show current configuration')
+    .action(async () => {
+      let secretKey: string
+      let source: string
+
+      const sourceLabels: Record<string, string> = {
+        flag: 'inline flag (--api-key)',
+        env: 'env var (FINTOC_SECRET_KEY)',
+        config: 'config file',
+      }
+
+      try {
+        const auth = resolveAuth()
+        secretKey = auth.secretKey
+        source = sourceLabels[auth.source]
+      } catch {
+        log('Not authenticated. Run `fintoc login` to get started.')
+        log('')
+        log(`  Config path:  ${CONFIG_PATH}`)
+        return
+      }
+
+      let orgName = '(unknown)'
+      let mode = '(unknown)'
+      let apiVersion = '(unknown)'
+
+      try {
+        const info = await whoami(secretKey)
+        orgName = info.organizationName
+        mode = info.mode
+        apiVersion = info.apiVersion
+      } catch {
+        warn('Unable to reach Fintoc API — showing cached config')
+      }
+
+      log(`  Organization:  ${orgName}`)
+      log(`  Mode:          ${mode}`)
+      log(`  Secret key:    ${maskKey(secretKey)}`)
+      log(`  API version:   ${apiVersion}`)
+      log(`  Config path:   ${CONFIG_PATH}`)
+      log(`  Source:        ${source}`)
+    })
+}

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -40,7 +40,7 @@ export const loginCommand = (program: Command): void => {
           process.exit(1)
         }
 
-        success(`Authenticated as ${info.organization_name} (${info.mode} mode)`)
+        success(`Authenticated as ${info.organizationName} (${info.mode} mode)`)
         log(`  Key stored in ${CONFIG_PATH}`)
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander'
 
+import { configCommand } from './commands/config.js'
 import { loginCommand } from './commands/login.js'
 import { logoutCommand } from './commands/logout.js'
 
@@ -16,5 +17,6 @@ program
 
 loginCommand(program)
 logoutCommand(program)
+configCommand(program)
 
 program.parse()

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -10,9 +10,9 @@ export type ResolvedAuth = {
 }
 
 export type WhoamiResponse = {
-  organization_name: string
+  organizationName: string
   mode: string
-  api_version: string
+  apiVersion: string
 }
 
 export const resolveAuth = (options?: { apiKey?: string }): ResolvedAuth => {
@@ -51,9 +51,12 @@ export const whoami = async (secretKey: string): Promise<WhoamiResponse> => {
   const client = createClient(secretKey)
   const result = await client.whoami.get('whoami')
   return {
-    organization_name: result.organization_name,
-    mode: result.mode,
-    api_version: result.api_version,
+    organizationName: result.organization.name,
+    mode: result.api_key.mode,
+    apiVersion:
+      result.organization.api_version instanceof Date
+        ? result.organization.api_version.toISOString().slice(0, 10)
+        : String(result.organization.api_version),
   }
 }
 


### PR DESCRIPTION
## Cambios

- [x] `src/commands/config.ts` — Muestra org, modo, key masked, config path y source de la key
- [x] Degradación graceful cuando la API no está disponible
- [x] Mensaje amigable cuando no hay autenticación

## Tests

Unitarios para los 3 escenarios: autenticado, sin key, y API inalcanzable.

<sup>*Created with Claude Code `/create-pr` command*</sup>