### PR TITLE
[ONB-1781] Resource registry: definición declarativa de los 8 recursos

### DIFF
--- a/src/resources/__tests__/registry.test.ts
+++ b/src/resources/__tests__/registry.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from 'vitest'
+
+import { resources } from '../registry.js'
+
+describe('resource registry', () => {
+  test('contains all 8 resources', () => {
+    expect(resources).toHaveLength(8)
+
+    const names = resources.map((r) => r.name)
+    expect(names).toEqual([
+      'payment_intents',
+      'transfers',
+      'accounts',
+      'webhook_endpoints',
+      'charges',
+      'subscriptions',
+      'links',
+      'api_keys',
+    ])
+  })
+
+  test('every resource has required fields', () => {
+    for (const resource of resources) {
+      expect(resource.name).toBeTruthy()
+      expect(resource.cliCommand).toBeTruthy()
+      expect(resource.sdkMethod).toBeTruthy()
+      expect(['v1', 'v2']).toContain(resource.sdkNamespace)
+      expect(resource.verbs.length).toBeGreaterThan(0)
+      expect(resource.priorityColumns.length).toBeGreaterThanOrEqual(1)
+      expect(resource.priorityColumns.length).toBeLessThanOrEqual(6)
+    }
+  })
+
+  test('verbs are valid', () => {
+    const validVerbs = new Set(['create', 'get', 'list', 'delete'])
+    for (const resource of resources) {
+      for (const verb of resource.verbs) {
+        expect(validVerbs.has(verb)).toBe(true)
+      }
+    }
+  })
+
+  test('resources with create verb have createFlags', () => {
+    for (const resource of resources) {
+      if (resource.verbs.includes('create')) {
+        expect(resource.createFlags).toBeDefined()
+        expect(resource.createFlags!.length).toBeGreaterThan(0)
+      }
+    }
+  })
+
+  test('createFlags with required=true exist for resources that need them', () => {
+    const paymentIntents = resources.find((r) => r.name === 'payment_intents')!
+    const requiredFlags = paymentIntents.createFlags!.filter((f) => f.required)
+    expect(requiredFlags.map((f) => f.name)).toEqual(['amount', 'currency'])
+  })
+
+  test('all flag types are valid', () => {
+    const validTypes = new Set(['string', 'number', 'boolean', 'string[]'])
+    for (const resource of resources) {
+      for (const flag of resource.createFlags ?? []) {
+        expect(validTypes.has(flag.type)).toBe(true)
+      }
+      for (const flag of resource.listFlags ?? []) {
+        expect(validTypes.has(flag.type)).toBe(true)
+      }
+    }
+  })
+
+  describe('v2 resources', () => {
+    test('transfers and accounts use v2 namespace', () => {
+      const transfers = resources.find((r) => r.name === 'transfers')!
+      const accounts = resources.find((r) => r.name === 'accounts')!
+
+      expect(transfers.sdkNamespace).toBe('v2')
+      expect(accounts.sdkNamespace).toBe('v2')
+    })
+
+    test('all other resources use v1 namespace', () => {
+      const v1Resources = resources.filter((r) => !['transfers', 'accounts'].includes(r.name))
+      for (const resource of v1Resources) {
+        expect(resource.sdkNamespace).toBe('v1')
+      }
+    })
+  })
+
+  describe('resource-specific verbs', () => {
+    test('api_keys only supports list', () => {
+      const apiKeys = resources.find((r) => r.name === 'api_keys')!
+      expect(apiKeys.verbs).toEqual(['list'])
+    })
+
+    test('webhook_endpoints and links support delete', () => {
+      const webhooks = resources.find((r) => r.name === 'webhook_endpoints')!
+      const links = resources.find((r) => r.name === 'links')!
+
+      expect(webhooks.verbs).toContain('delete')
+      expect(links.verbs).toContain('delete')
+    })
+
+    test('subscriptions and accounts are read-only (get + list)', () => {
+      const subscriptions = resources.find((r) => r.name === 'subscriptions')!
+      const accounts = resources.find((r) => r.name === 'accounts')!
+
+      expect(subscriptions.verbs).toEqual(['get', 'list'])
+      expect(accounts.verbs).toEqual(['get', 'list'])
+    })
+  })
+
+  describe('transfers create flags', () => {
+    test('requires amount, currency, and counterparty-account-number', () => {
+      const transfers = resources.find((r) => r.name === 'transfers')!
+      const requiredFlags = transfers.createFlags!.filter((f) => f.required)
+      expect(requiredFlags.map((f) => f.name)).toEqual([
+        'amount',
+        'currency',
+        'counterparty-account-number',
+      ])
+    })
+  })
+
+  describe('webhook_endpoints create flags', () => {
+    test('requires url and enabled-events', () => {
+      const webhooks = resources.find((r) => r.name === 'webhook_endpoints')!
+      const requiredFlags = webhooks.createFlags!.filter((f) => f.required)
+      expect(requiredFlags.map((f) => f.name)).toEqual(['url', 'enabled-events'])
+    })
+
+    test('enabled-events is string[] type', () => {
+      const webhooks = resources.find((r) => r.name === 'webhook_endpoints')!
+      const eventsFlag = webhooks.createFlags!.find((f) => f.name === 'enabled-events')!
+      expect(eventsFlag.type).toBe('string[]')
+    })
+  })
+})

--- a/src/resources/registry.ts
+++ b/src/resources/registry.ts
@@ -1,0 +1,214 @@
+import type { ResourceDef } from '../types.js'
+
+export const resources: ResourceDef[] = [
+  {
+    name: 'payment_intents',
+    cliCommand: 'payment_intents',
+    sdkMethod: 'paymentIntents',
+    sdkNamespace: 'v1',
+    verbs: ['create', 'get', 'list'],
+    priorityColumns: ['id', 'amount', 'currency', 'status', 'created_at'],
+    createFlags: [
+      {
+        name: 'amount',
+        type: 'number',
+        required: true,
+        description: 'Amount in smallest currency unit',
+      },
+      {
+        name: 'currency',
+        type: 'string',
+        required: true,
+        description: 'Currency code (e.g., CLP, MXN)',
+      },
+      {
+        name: 'customer-email',
+        type: 'string',
+        description: 'Customer email address',
+      },
+    ],
+    listFlags: [
+      {
+        name: 'status',
+        type: 'string',
+        description: 'Filter by status (pending, succeeded, failed, expired)',
+      },
+      {
+        name: 'since',
+        type: 'string',
+        description: 'Show results created after this date (ISO 8601)',
+      },
+      {
+        name: 'until',
+        type: 'string',
+        description: 'Show results created before this date (ISO 8601)',
+      },
+    ],
+  },
+  {
+    name: 'transfers',
+    cliCommand: 'transfers',
+    sdkMethod: 'transfers',
+    sdkNamespace: 'v2',
+    verbs: ['create', 'get', 'list'],
+    priorityColumns: ['id', 'amount', 'currency', 'status', 'created_at'],
+    createFlags: [
+      {
+        name: 'amount',
+        type: 'number',
+        required: true,
+        description: 'Amount in smallest currency unit',
+      },
+      {
+        name: 'currency',
+        type: 'string',
+        required: true,
+        description: 'Currency code (e.g., CLP)',
+      },
+      {
+        name: 'counterparty-account-number',
+        type: 'string',
+        required: true,
+        description: 'Destination account number',
+      },
+    ],
+    listFlags: [
+      {
+        name: 'status',
+        type: 'string',
+        description: 'Filter by status (pending, succeeded, failed, rejected)',
+      },
+      {
+        name: 'since',
+        type: 'string',
+        description: 'Show results created after this date (ISO 8601)',
+      },
+      {
+        name: 'until',
+        type: 'string',
+        description: 'Show results created before this date (ISO 8601)',
+      },
+    ],
+  },
+  {
+    name: 'accounts',
+    cliCommand: 'accounts',
+    sdkMethod: 'accounts',
+    sdkNamespace: 'v2',
+    verbs: ['get', 'list'],
+    priorityColumns: ['id', 'name', 'type', 'currency', 'balance', 'status'],
+    listFlags: [{ name: 'type', type: 'string', description: 'Filter by account type' }],
+  },
+  {
+    name: 'webhook_endpoints',
+    cliCommand: 'webhook_endpoints',
+    sdkMethod: 'webhookEndpoints',
+    sdkNamespace: 'v1',
+    verbs: ['create', 'get', 'list', 'delete'],
+    priorityColumns: ['id', 'url', 'status', 'enabled_events', 'created_at'],
+    createFlags: [
+      {
+        name: 'url',
+        type: 'string',
+        required: true,
+        description: 'Endpoint URL to receive webhooks',
+      },
+      {
+        name: 'enabled-events',
+        type: 'string[]',
+        required: true,
+        description: 'Events to subscribe to (comma-separated)',
+      },
+      { name: 'description', type: 'string', description: 'Description of the webhook endpoint' },
+    ],
+    listFlags: [],
+  },
+  {
+    name: 'charges',
+    cliCommand: 'charges',
+    sdkMethod: 'charges',
+    sdkNamespace: 'v1',
+    verbs: ['create', 'get', 'list'],
+    priorityColumns: ['id', 'amount', 'currency', 'status', 'created_at'],
+    createFlags: [
+      {
+        name: 'amount',
+        type: 'number',
+        required: true,
+        description: 'Amount in smallest currency unit',
+      },
+      {
+        name: 'currency',
+        type: 'string',
+        required: true,
+        description: 'Currency code (e.g., CLP, MXN)',
+      },
+    ],
+    listFlags: [
+      {
+        name: 'status',
+        type: 'string',
+        description: 'Filter by status (pending, in_progress, succeeded, failed)',
+      },
+      {
+        name: 'since',
+        type: 'string',
+        description: 'Show results created after this date (ISO 8601)',
+      },
+      {
+        name: 'until',
+        type: 'string',
+        description: 'Show results created before this date (ISO 8601)',
+      },
+      {
+        name: 'subscription-id',
+        type: 'string',
+        description: 'Filter by subscription ID',
+      },
+    ],
+  },
+  {
+    name: 'subscriptions',
+    cliCommand: 'subscriptions',
+    sdkMethod: 'subscriptions',
+    sdkNamespace: 'v1',
+    verbs: ['get', 'list'],
+    priorityColumns: ['id', 'status', 'amount', 'currency', 'created_at'],
+    listFlags: [
+      {
+        name: 'since',
+        type: 'string',
+        description: 'Show results created after this date (ISO 8601)',
+      },
+      {
+        name: 'until',
+        type: 'string',
+        description: 'Show results created before this date (ISO 8601)',
+      },
+    ],
+  },
+  {
+    name: 'links',
+    cliCommand: 'links',
+    sdkMethod: 'links',
+    sdkNamespace: 'v1',
+    verbs: ['get', 'list', 'delete'],
+    priorityColumns: ['id', 'holder_name', 'institution', 'status', 'created_at'],
+    listFlags: [
+      {
+        name: 'status',
+        type: 'string',
+        description: 'Filter by status (active, inactive, login_required)',
+      },
+    ],
+  },
+  {
+    name: 'api_keys',
+    cliCommand: 'api_keys',
+    sdkMethod: 'apiKeys',
+    sdkNamespace: 'v1',
+    verbs: ['list'],
+    priorityColumns: ['id', 'name', 'mode', 'last_four', 'created_at'],
+    listFlags: [],
+  },
+]

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,3 +2,25 @@ export type FintocConfig = {
   secret_key?: string
   jws_private_key?: string
 }
+
+export type Verb = 'create' | 'get' | 'list' | 'delete'
+
+export type FlagType = 'string' | 'number' | 'boolean' | 'string[]'
+
+export type FlagDef = {
+  name: string
+  type: FlagType
+  required?: boolean
+  description?: string
+}
+
+export type ResourceDef = {
+  name: string
+  cliCommand: string
+  sdkMethod: string
+  sdkNamespace: 'v1' | 'v2'
+  verbs: Verb[]
+  priorityColumns: string[]
+  createFlags?: FlagDef[]
+  listFlags?: FlagDef[]
+}


### PR DESCRIPTION
## Cambios

- [x] Tipos `ResourceDef`, `FlagDef`, `Verb` y `FlagType` en `src/types.ts`
- [x] Registry con los 8 recursos, sus verbs, createFlags, listFlags y priorityColumns
- [x] `transfers` y `accounts` en namespace `v2`, el resto en `v1`

## Tests

Unitarios para estructura del registry y validación de verbs/flags por recurso.

<sup>*Created with Claude Code `/create-pr` command*</sup>