### PR TITLE
[ONB-1782] Factory de comandos y output formatting para recursos

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -4,7 +4,7 @@ import { maskKey, resolveAuth, whoami } from '../lib/auth.js'
 import { CONFIG_PATH } from '../lib/config.js'
 import { log, warn } from '../lib/output.js'
 
-export const configCommand = (program: Command): void => {
+export const configCommand = (program: Command) => {
   program
     .command('config')
     .description('Show current configuration')
@@ -12,11 +12,11 @@ export const configCommand = (program: Command): void => {
       let secretKey: string
       let source: string
 
-      const sourceLabels: Record<string, string> = {
+      const sourceLabels = {
         flag: 'inline flag (--api-key)',
         env: 'env var (FINTOC_SECRET_KEY)',
         config: 'config file',
-      }
+      } satisfies Record<string, string>
 
       try {
         const auth = resolveAuth()

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -6,7 +6,7 @@ import { whoami } from '../lib/auth.js'
 import { CONFIG_PATH, readConfig, writeConfig } from '../lib/config.js'
 import { error, log, success } from '../lib/output.js'
 
-export const loginCommand = (program: Command): void => {
+export const loginCommand = (program: Command) => {
   program
     .command('login')
     .description('Authenticate with your Fintoc API key')

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -3,7 +3,7 @@ import type { Command } from 'commander'
 import { clearConfig, CONFIG_PATH } from '../lib/config.js'
 import { success } from '../lib/output.js'
 
-export const logoutCommand = (program: Command): void => {
+export const logoutCommand = (program: Command) => {
   program
     .command('logout')
     .description('Remove stored credentials')

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ import { Command } from 'commander'
 import { configCommand } from './commands/config.js'
 import { loginCommand } from './commands/login.js'
 import { logoutCommand } from './commands/logout.js'
+import { registerResourceCommands } from './resources/factory.js'
+import { resources } from './resources/registry.js'
 
 declare const __CLI_VERSION__: string
 
@@ -14,9 +16,12 @@ program
   .name('fintoc')
   .description('Fintoc CLI — manage your Fintoc resources from the terminal')
   .version(versionString, '-v, --version')
+  .option('--api-key <key>', 'Override API key for this command')
+  .option('--json', 'Output as JSON')
 
 loginCommand(program)
 logoutCommand(program)
 configCommand(program)
+registerResourceCommands(program, resources)
 
 program.parse()

--- a/src/lib/__tests__/output.test.ts
+++ b/src/lib/__tests__/output.test.ts
@@ -1,6 +1,16 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
 
-import { error, log, success, warn } from '../output.js'
+import {
+  colorizeStatus,
+  error,
+  formatValue,
+  log,
+  printDetail,
+  printJson,
+  printTable,
+  success,
+  warn,
+} from '../output.js'
 
 describe('output', () => {
   afterEach(() => {
@@ -29,5 +39,167 @@ describe('output', () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
     warn('careful')
     expect(spy).toHaveBeenCalledWith('⚠ careful')
+  })
+})
+
+describe('colorizeStatus', () => {
+  test('applies green to succeeded', () => {
+    const result = colorizeStatus('succeeded')
+    expect(result).toContain('succeeded')
+    expect(result).toContain('\x1B[32m')
+  })
+
+  test('applies yellow to pending', () => {
+    const result = colorizeStatus('pending')
+    expect(result).toContain('pending')
+    expect(result).toContain('\x1B[33m')
+  })
+
+  test('applies red to failed', () => {
+    const result = colorizeStatus('failed')
+    expect(result).toContain('failed')
+    expect(result).toContain('\x1B[31m')
+  })
+
+  test('returns unknown status uncolored', () => {
+    expect(colorizeStatus('custom')).toBe('custom')
+  })
+})
+
+describe('formatValue', () => {
+  test('formats null as dim dash', () => {
+    const result = formatValue('id', null)
+    expect(result).toContain('—')
+  })
+
+  test('formats undefined as dim dash', () => {
+    const result = formatValue('id', undefined)
+    expect(result).toContain('—')
+  })
+
+  test('colorizes status values', () => {
+    const result = formatValue('status', 'succeeded')
+    expect(result).toContain('\x1B[32m')
+  })
+
+  test('formats Date as YYYY-MM-DD', () => {
+    const result = formatValue('created_at', new Date('2026-04-22T12:00:00Z'))
+    expect(result).toBe('2026-04-22')
+  })
+
+  test('joins arrays with commas', () => {
+    expect(formatValue('events', ['a', 'b', 'c'])).toBe('a, b, c')
+  })
+
+  test('converts other values to string', () => {
+    expect(formatValue('amount', 10000)).toBe('10000')
+  })
+})
+
+describe('printTable', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('prints no results message for empty rows', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    printTable({ columns: ['id'], rows: [] })
+    expect(spy).toHaveBeenCalledWith('No results found.')
+  })
+
+  test('prints header and rows', () => {
+    const calls: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((msg: string) => {
+      calls.push(msg)
+    })
+
+    printTable({
+      columns: ['id', 'status'],
+      rows: [
+        { id: 'pi_123', status: 'pending' },
+        { id: 'pi_456', status: 'succeeded' },
+      ],
+    })
+
+    expect(calls[0]).toContain('ID')
+    expect(calls[0]).toContain('STATUS')
+    expect(calls[1]).toContain('pi_123')
+    expect(calls[2]).toContain('pi_456')
+    expect(calls[4]).toContain('Showing 2 results')
+  })
+
+  test('shows "X of Y" when total exceeds shown', () => {
+    const calls: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((msg: string) => {
+      calls.push(msg)
+    })
+
+    printTable({
+      columns: ['id'],
+      rows: [{ id: 'pi_123' }],
+      total: 50,
+    })
+
+    const footer = calls.find((c) => c.includes('Showing'))
+    expect(footer).toContain('1 of 50')
+  })
+
+  test('uses singular "result" for single row', () => {
+    const calls: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((msg: string) => {
+      calls.push(msg)
+    })
+
+    printTable({
+      columns: ['id'],
+      rows: [{ id: 'pi_123' }],
+    })
+
+    const footer = calls.find((c) => c.includes('Showing'))
+    expect(footer).toContain('1 result')
+  })
+})
+
+describe('printJson', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('prints formatted JSON', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    printJson({ id: 'pi_123', amount: 10000 })
+    expect(spy).toHaveBeenCalledWith(JSON.stringify({ id: 'pi_123', amount: 10000 }, null, 2))
+  })
+})
+
+describe('printDetail', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('prints key-value pairs', () => {
+    const calls: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((msg: string) => {
+      calls.push(msg)
+    })
+
+    printDetail({ id: 'pi_123', amount: 10000 })
+
+    expect(calls[0]).toContain('id')
+    expect(calls[0]).toContain('pi_123')
+    expect(calls[1]).toContain('amount')
+    expect(calls[1]).toContain('10000')
+  })
+
+  test('respects column filter', () => {
+    const calls: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((msg: string) => {
+      calls.push(msg)
+    })
+
+    printDetail({ id: 'pi_123', amount: 10000, secret: 'hidden' }, ['id', 'amount'])
+
+    expect(calls).toHaveLength(2)
+    expect(calls.every((c) => !c.includes('hidden'))).toBe(true)
   })
 })

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -15,19 +15,19 @@ export type WhoamiResponse = {
   apiVersion: string
 }
 
-export const resolveAuth = (options?: { apiKey?: string }): ResolvedAuth => {
+export const resolveAuth = (options?: { apiKey?: string }) => {
   if (options?.apiKey) {
-    return { secretKey: options.apiKey, source: 'flag' }
+    return { secretKey: options.apiKey, source: 'flag' as const }
   }
 
   const envKey = process.env.FINTOC_SECRET_KEY
   if (envKey) {
-    return { secretKey: envKey, source: 'env' }
+    return { secretKey: envKey, source: 'env' as const }
   }
 
   const config = readConfig()
   if (config.secret_key) {
-    return { secretKey: config.secret_key, source: 'config' }
+    return { secretKey: config.secret_key, source: 'config' as const }
   }
 
   throw new Error(
@@ -43,11 +43,11 @@ export const resolveAuth = (options?: { apiKey?: string }): ResolvedAuth => {
   )
 }
 
-export const createClient = (secretKey: string, jwsPrivateKey?: string): Fintoc => {
+export const createClient = (secretKey: string, jwsPrivateKey?: string) => {
   return new Fintoc(secretKey, jwsPrivateKey)
 }
 
-export const whoami = async (secretKey: string): Promise<WhoamiResponse> => {
+export const whoami = async (secretKey: string) => {
   const client = createClient(secretKey)
   const result = await client.whoami.get('whoami')
   return {
@@ -60,7 +60,7 @@ export const whoami = async (secretKey: string): Promise<WhoamiResponse> => {
   }
 }
 
-export const maskKey = (key: string): string => {
+export const maskKey = (key: string) => {
   const prefixMatch = key.match(/^(sk_(?:test|live)_)/)
   if (prefixMatch) {
     return `${prefixMatch[1]}····`

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -9,8 +9,8 @@ import { parse, stringify } from 'smol-toml'
 export const CONFIG_DIR = join(homedir(), '.fintoc')
 export const CONFIG_PATH = join(CONFIG_DIR, 'config.toml')
 
-const isFileNotFound = (err: unknown): boolean =>
-  err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT'
+const isFileNotFound = (err: unknown) =>
+  err instanceof Error && 'code' in err && err.code === 'ENOENT'
 
 export const readConfig = (): FintocConfig => {
   try {
@@ -22,7 +22,7 @@ export const readConfig = (): FintocConfig => {
   }
 }
 
-export const writeConfig = (config: FintocConfig): void => {
+export const writeConfig = (config: FintocConfig) => {
   mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 })
 
   const clean = Object.fromEntries(Object.entries(config).filter(([, v]) => v !== undefined))
@@ -30,7 +30,7 @@ export const writeConfig = (config: FintocConfig): void => {
   writeFileSync(CONFIG_PATH, stringify(clean), { mode: 0o600 })
 }
 
-export const clearConfig = (): void => {
+export const clearConfig = () => {
   try {
     unlinkSync(CONFIG_PATH)
   } catch (err) {

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -1,28 +1,28 @@
 /* eslint-disable no-console */
 
-export const log = (message: string): void => {
+export const log = (message: string) => {
   console.log(message)
 }
 
-export const success = (message: string): void => {
+export const success = (message: string) => {
   console.log(`✔ ${message}`)
 }
 
-export const error = (message: string): void => {
+export const error = (message: string) => {
   console.error(`✘ ${message}`)
 }
 
-export const warn = (message: string): void => {
+export const warn = (message: string) => {
   console.error(`⚠ ${message}`)
 }
 
 // ANSI color helpers
-const green = (text: string): string => `\x1B[32m${text}\x1B[0m`
-const yellow = (text: string): string => `\x1B[33m${text}\x1B[0m`
-const red = (text: string): string => `\x1B[31m${text}\x1B[0m`
-const dim = (text: string): string => `\x1B[2m${text}\x1B[0m`
+const green = (text: string) => `\x1B[32m${text}\x1B[0m`
+const yellow = (text: string) => `\x1B[33m${text}\x1B[0m`
+const red = (text: string) => `\x1B[31m${text}\x1B[0m`
+const dim = (text: string) => `\x1B[2m${text}\x1B[0m`
 
-const STATUS_ICONS: Record<string, (text: string) => string> = {
+const STATUS_COLORS = {
   succeeded: green,
   active: green,
   paid: green,
@@ -36,16 +36,16 @@ const STATUS_ICONS: Record<string, (text: string) => string> = {
   expired: red,
   inactive: red,
   disabled: red,
-}
+} satisfies Record<string, (text: string) => string>
 
-export const colorizeStatus = (status: string): string => {
-  const colorFn = STATUS_ICONS[status]
-  return colorFn ? colorFn(status) : status
+export const colorizeStatus = (status: string) => {
+  if (!(status in STATUS_COLORS)) return status
+  return STATUS_COLORS[status as keyof typeof STATUS_COLORS](status)
 }
 
 // Strip ANSI codes for width calculation
 // eslint-disable-next-line no-control-regex
-const stripAnsi = (str: string): string => str.replace(/\x1B\[[0-9;]*m/g, '')
+const stripAnsi = (str: string) => str.replace(/\x1B\[[0-9;]*m/g, '')
 
 export type TableOptions = {
   columns: string[]
@@ -53,7 +53,7 @@ export type TableOptions = {
   total?: number
 }
 
-export const formatValue = (key: string, value: unknown): string => {
+export const formatValue = (key: string, value: unknown) => {
   if (value === null || value === undefined) return dim('—')
   if (key === 'status') return colorizeStatus(String(value))
   if (value instanceof Date) return value.toISOString().slice(0, 10)
@@ -61,7 +61,7 @@ export const formatValue = (key: string, value: unknown): string => {
   return String(value)
 }
 
-export const printTable = ({ columns, rows, total }: TableOptions): void => {
+export const printTable = ({ columns, rows, total }: TableOptions) => {
   if (rows.length === 0) {
     log('No results found.')
     return
@@ -102,12 +102,14 @@ export const printTable = ({ columns, rows, total }: TableOptions): void => {
   }
 }
 
-export const printJson = (data: unknown): void => {
+export const printJson = (data: unknown) => {
   console.log(JSON.stringify(data, null, 2))
 }
 
-export const printDetail = (data: Record<string, unknown>, columns?: string[]): void => {
+export const printDetail = (data: Record<string, unknown>, columns?: string[]) => {
   const keys = columns ?? Object.keys(data)
+  if (keys.length === 0) return
+
   const maxKeyLen = Math.max(...keys.map((k) => k.length))
 
   for (const key of keys) {

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -15,3 +15,105 @@ export const error = (message: string): void => {
 export const warn = (message: string): void => {
   console.error(`⚠ ${message}`)
 }
+
+// ANSI color helpers
+const green = (text: string): string => `\x1B[32m${text}\x1B[0m`
+const yellow = (text: string): string => `\x1B[33m${text}\x1B[0m`
+const red = (text: string): string => `\x1B[31m${text}\x1B[0m`
+const dim = (text: string): string => `\x1B[2m${text}\x1B[0m`
+
+const STATUS_ICONS: Record<string, (text: string) => string> = {
+  succeeded: green,
+  active: green,
+  paid: green,
+  enabled: green,
+  pending: yellow,
+  processing: yellow,
+  in_progress: yellow,
+  login_required: yellow,
+  failed: red,
+  rejected: red,
+  expired: red,
+  inactive: red,
+  disabled: red,
+}
+
+export const colorizeStatus = (status: string): string => {
+  const colorFn = STATUS_ICONS[status]
+  return colorFn ? colorFn(status) : status
+}
+
+// Strip ANSI codes for width calculation
+// eslint-disable-next-line no-control-regex
+const stripAnsi = (str: string): string => str.replace(/\x1B\[[0-9;]*m/g, '')
+
+export type TableOptions = {
+  columns: string[]
+  rows: Record<string, unknown>[]
+  total?: number
+}
+
+export const formatValue = (key: string, value: unknown): string => {
+  if (value === null || value === undefined) return dim('—')
+  if (key === 'status') return colorizeStatus(String(value))
+  if (value instanceof Date) return value.toISOString().slice(0, 10)
+  if (Array.isArray(value)) return value.join(', ')
+  return String(value)
+}
+
+export const printTable = ({ columns, rows, total }: TableOptions): void => {
+  if (rows.length === 0) {
+    log('No results found.')
+    return
+  }
+
+  // Build formatted rows (with ANSI codes for display)
+  const formattedRows = rows.map((row) => columns.map((col) => formatValue(col, row[col])))
+
+  // Calculate column widths using stripped ANSI text
+  const headers = columns.map((col) => col.toUpperCase())
+  const widths = columns.map((col, i) => {
+    const cellWidths = formattedRows.map((row) => stripAnsi(row[i]).length)
+    return Math.max(headers[i].length, ...cellWidths)
+  })
+
+  // Print header
+  const headerLine = headers.map((h, i) => h.padEnd(widths[i])).join('  ')
+  log(dim(`  ${headerLine}`))
+
+  // Print rows
+  for (const row of formattedRows) {
+    const line = row
+      .map((cell, i) => {
+        const padding = widths[i] - stripAnsi(cell).length
+        return cell + ' '.repeat(Math.max(0, padding))
+      })
+      .join('  ')
+    log(`  ${line}`)
+  }
+
+  // Footer
+  log('')
+  const shown = rows.length
+  if (total !== undefined && total > shown) {
+    log(`Showing ${shown} of ${total} results`)
+  } else {
+    log(`Showing ${shown} ${shown === 1 ? 'result' : 'results'}`)
+  }
+}
+
+export const printJson = (data: unknown): void => {
+  console.log(JSON.stringify(data, null, 2))
+}
+
+export const printDetail = (data: Record<string, unknown>, columns?: string[]): void => {
+  const keys = columns ?? Object.keys(data)
+  const maxKeyLen = Math.max(...keys.map((k) => k.length))
+
+  for (const key of keys) {
+    if (!(key in data)) continue
+    const label = key.padEnd(maxKeyLen)
+    const value = formatValue(key, data[key])
+    log(`${label}  ${value}`)
+  }
+}

--- a/src/resources/__tests__/factory.test.ts
+++ b/src/resources/__tests__/factory.test.ts
@@ -49,6 +49,7 @@ const asyncGenerator = (items: { serialize: () => Record<string, unknown> }[]) =
 
 const testResource: ResourceDef = {
   name: 'payment_intents',
+  displayName: 'payment intent',
   cliCommand: 'payment_intents',
   sdkMethod: 'paymentIntents',
   sdkNamespace: 'v1',
@@ -406,6 +407,7 @@ describe('factory: v2 namespace', () => {
 
     const v2Resource: ResourceDef = {
       name: 'transfers',
+      displayName: 'transfer',
       cliCommand: 'transfers',
       sdkMethod: 'transfers',
       sdkNamespace: 'v2',

--- a/src/resources/__tests__/factory.test.ts
+++ b/src/resources/__tests__/factory.test.ts
@@ -1,0 +1,422 @@
+import type { ResourceDef } from '../../types.js'
+import { Command } from 'commander'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { error, log, printDetail, printJson, printTable, success } from '../../lib/output.js'
+import { registerResourceCommands } from '../factory.js'
+
+const { mockManager, mockClient } = vi.hoisted(() => {
+  const mockManager = {
+    create: vi.fn(),
+    get: vi.fn(),
+    list: vi.fn(),
+    delete: vi.fn(),
+  }
+  const mockClient = {
+    paymentIntents: mockManager,
+  }
+  return { mockManager, mockClient }
+})
+
+vi.mock('../../lib/auth.js', () => ({
+  resolveAuth: vi.fn(() => ({ secretKey: 'sk_test_123', source: 'config' })),
+  createClient: vi.fn(() => mockClient),
+}))
+
+vi.mock('../../lib/config.js', () => ({
+  readConfig: vi.fn(() => ({})),
+}))
+
+vi.mock('../../lib/output.js', () => ({
+  log: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  printTable: vi.fn(),
+  printJson: vi.fn(),
+  printDetail: vi.fn(),
+}))
+
+vi.mock('@inquirer/prompts', () => ({
+  confirm: vi.fn(() => true),
+}))
+
+// Mock async generator helper
+const asyncGenerator = (items: { serialize: () => Record<string, unknown> }[]) => {
+  return (async function* () {
+    for (const item of items) yield item
+  })()
+}
+
+const testResource: ResourceDef = {
+  name: 'payment_intents',
+  cliCommand: 'payment_intents',
+  sdkMethod: 'paymentIntents',
+  sdkNamespace: 'v1',
+  verbs: ['create', 'get', 'list', 'delete'],
+  priorityColumns: ['id', 'amount', 'currency', 'status', 'created_at'],
+  createFlags: [
+    { name: 'amount', type: 'number', required: true, description: 'Amount' },
+    { name: 'currency', type: 'string', required: true, description: 'Currency code' },
+    { name: 'customer-email', type: 'string', description: 'Customer email' },
+  ],
+  listFlags: [{ name: 'status', type: 'string', description: 'Filter by status' }],
+}
+
+const createProgram = (resource: ResourceDef = testResource) => {
+  const program = new Command()
+  program.exitOverride()
+  program.option('--api-key <key>', 'Override API key').option('--json', 'Output as JSON')
+  registerResourceCommands(program, [resource])
+  return program
+}
+
+describe('factory: registerResourceCommands', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('registers subcommands for each verb', () => {
+    const program = createProgram()
+    const resourceCmd = program.commands.find((c) => c.name() === 'payment_intents')!
+
+    expect(resourceCmd).toBeDefined()
+
+    const subcommandNames = resourceCmd.commands.map((c) => c.name())
+    expect(subcommandNames).toContain('create')
+    expect(subcommandNames).toContain('get')
+    expect(subcommandNames).toContain('list')
+    expect(subcommandNames).toContain('delete')
+  })
+
+  test('only registers verbs from the resource def', () => {
+    const readOnlyResource: ResourceDef = {
+      ...testResource,
+      name: 'accounts',
+      cliCommand: 'accounts',
+      verbs: ['get', 'list'],
+    }
+
+    const program = createProgram(readOnlyResource)
+    const resourceCmd = program.commands.find((c) => c.name() === 'accounts')!
+    const subcommandNames = resourceCmd.commands.map((c) => c.name())
+
+    expect(subcommandNames).toContain('get')
+    expect(subcommandNames).toContain('list')
+    expect(subcommandNames).not.toContain('create')
+    expect(subcommandNames).not.toContain('delete')
+  })
+})
+
+describe('factory: create command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('calls SDK create with parsed flags', async () => {
+    const mockResult = { serialize: () => ({ id: 'pi_123', amount: 10000, currency: 'CLP' }) }
+    mockManager.create.mockResolvedValue(mockResult)
+
+    const program = createProgram()
+    await program.parseAsync(
+      ['payment_intents', 'create', '--amount', '10000', '--currency', 'CLP'],
+      { from: 'user' },
+    )
+
+    expect(mockManager.create).toHaveBeenCalledWith({
+      amount: 10000,
+      currency: 'CLP',
+    })
+    expect(success).toHaveBeenCalled()
+    expect(printDetail).toHaveBeenCalled()
+  })
+
+  test('converts kebab-case flags to snake_case for SDK', async () => {
+    const mockResult = { serialize: () => ({ id: 'pi_123' }) }
+    mockManager.create.mockResolvedValue(mockResult)
+
+    const program = createProgram()
+    await program.parseAsync(
+      [
+        'payment_intents',
+        'create',
+        '--amount',
+        '10000',
+        '--currency',
+        'CLP',
+        '--customer-email',
+        'test@example.com',
+      ],
+      { from: 'user' },
+    )
+
+    expect(mockManager.create).toHaveBeenCalledWith({
+      amount: 10000,
+      currency: 'CLP',
+      customer_email: 'test@example.com',
+    })
+  })
+
+  test('exits with error on missing required flags', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit')
+    })
+
+    const program = createProgram()
+    await expect(
+      program.parseAsync(['payment_intents', 'create', '--currency', 'CLP'], { from: 'user' }),
+    ).rejects.toThrow('process.exit')
+
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('--amount'))
+    exitSpy.mockRestore()
+  })
+
+  test('outputs JSON when --json flag is set', async () => {
+    const mockResult = { serialize: () => ({ id: 'pi_123', amount: 10000 }) }
+    mockManager.create.mockResolvedValue(mockResult)
+
+    const program = createProgram()
+    await program.parseAsync(
+      ['--json', 'payment_intents', 'create', '--amount', '10000', '--currency', 'CLP'],
+      { from: 'user' },
+    )
+
+    expect(printJson).toHaveBeenCalledWith({ id: 'pi_123', amount: 10000 })
+    expect(printDetail).not.toHaveBeenCalled()
+  })
+})
+
+describe('factory: get command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('calls SDK get with ID', async () => {
+    const mockResult = { serialize: () => ({ id: 'pi_123', amount: 10000 }) }
+    mockManager.get.mockResolvedValue(mockResult)
+
+    const program = createProgram()
+    await program.parseAsync(['payment_intents', 'get', 'pi_123'], { from: 'user' })
+
+    expect(mockManager.get).toHaveBeenCalledWith('pi_123')
+    expect(printDetail).toHaveBeenCalled()
+  })
+
+  test('outputs JSON when --json flag is set', async () => {
+    const mockResult = { serialize: () => ({ id: 'pi_123' }) }
+    mockManager.get.mockResolvedValue(mockResult)
+
+    const program = createProgram()
+    await program.parseAsync(['--json', 'payment_intents', 'get', 'pi_123'], { from: 'user' })
+
+    expect(printJson).toHaveBeenCalledWith({ id: 'pi_123' })
+  })
+})
+
+describe('factory: list command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('calls SDK list with lazy mode and respects limit', async () => {
+    const items = Array.from({ length: 20 }, (_, i) => ({
+      serialize: () => ({ id: `pi_${i}` }),
+    }))
+    mockManager.list.mockResolvedValue(asyncGenerator(items))
+
+    const program = createProgram()
+    await program.parseAsync(['payment_intents', 'list', '--limit', '5'], { from: 'user' })
+
+    expect(mockManager.list).toHaveBeenCalledWith(expect.objectContaining({ lazy: true }))
+    expect(printTable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rows: expect.arrayContaining([expect.objectContaining({ id: 'pi_0' })]),
+      }),
+    )
+    // Should have only 5 items due to limit
+    const call = vi.mocked(printTable).mock.calls[0][0]
+    expect(call.rows).toHaveLength(5)
+  })
+
+  test('passes filter flags to SDK', async () => {
+    mockManager.list.mockResolvedValue(asyncGenerator([]))
+
+    const program = createProgram()
+    await program.parseAsync(['payment_intents', 'list', '--status', 'succeeded'], { from: 'user' })
+
+    expect(mockManager.list).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'succeeded', lazy: true }),
+    )
+  })
+
+  test('defaults limit to 10', async () => {
+    const items = Array.from({ length: 15 }, (_, i) => ({
+      serialize: () => ({ id: `pi_${i}` }),
+    }))
+    mockManager.list.mockResolvedValue(asyncGenerator(items))
+
+    const program = createProgram()
+    await program.parseAsync(['payment_intents', 'list'], { from: 'user' })
+
+    const call = vi.mocked(printTable).mock.calls[0][0]
+    expect(call.rows).toHaveLength(10)
+  })
+
+  test('outputs JSON when --json flag is set', async () => {
+    const items = [{ serialize: () => ({ id: 'pi_0' }) }]
+    mockManager.list.mockResolvedValue(asyncGenerator(items))
+
+    const program = createProgram()
+    await program.parseAsync(['--json', 'payment_intents', 'list'], { from: 'user' })
+
+    expect(printJson).toHaveBeenCalledWith([{ id: 'pi_0' }])
+    expect(printTable).not.toHaveBeenCalled()
+  })
+
+  test('exits with error when --limit is not a valid number', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit')
+    })
+
+    const program = createProgram()
+    await expect(
+      program.parseAsync(['payment_intents', 'list', '--limit', 'abc'], { from: 'user' }),
+    ).rejects.toThrow('process.exit')
+
+    expect(error).toHaveBeenCalledWith('--limit must be a positive number')
+    expect(mockManager.list).not.toHaveBeenCalled()
+    exitSpy.mockRestore()
+  })
+
+  test('exits with error when --limit is zero', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit')
+    })
+
+    const program = createProgram()
+    await expect(
+      program.parseAsync(['payment_intents', 'list', '--limit', '0'], { from: 'user' }),
+    ).rejects.toThrow('process.exit')
+
+    expect(error).toHaveBeenCalledWith('--limit must be a positive number')
+    expect(mockManager.list).not.toHaveBeenCalled()
+    exitSpy.mockRestore()
+  })
+
+  test('exits with error when --limit is negative', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit')
+    })
+
+    const program = createProgram()
+    await expect(
+      program.parseAsync(['payment_intents', 'list', '--limit', '-5'], { from: 'user' }),
+    ).rejects.toThrow('process.exit')
+
+    expect(error).toHaveBeenCalledWith('--limit must be a positive number')
+    expect(mockManager.list).not.toHaveBeenCalled()
+    exitSpy.mockRestore()
+  })
+})
+
+describe('factory: delete command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('calls SDK delete with confirmation skipped via --yes', async () => {
+    mockManager.delete.mockResolvedValue('deleted')
+
+    const program = createProgram()
+    await program.parseAsync(['payment_intents', 'delete', 'pi_123', '--yes'], { from: 'user' })
+
+    expect(mockManager.delete).toHaveBeenCalledWith('pi_123')
+    expect(success).toHaveBeenCalledWith(expect.stringContaining('pi_123'))
+  })
+
+  test('exits with error in non-TTY without --yes', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit')
+    })
+
+    const originalIsTTY = process.stdin.isTTY
+    process.stdin.isTTY = false
+
+    const program = createProgram()
+    await expect(
+      program.parseAsync(['payment_intents', 'delete', 'pi_123'], { from: 'user' }),
+    ).rejects.toThrow('process.exit')
+
+    expect(mockManager.delete).not.toHaveBeenCalled()
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('--yes'))
+
+    process.stdin.isTTY = originalIsTTY
+    exitSpy.mockRestore()
+  })
+
+  test('aborts when user declines confirmation', async () => {
+    const { confirm } = await import('@inquirer/prompts')
+    vi.mocked(confirm).mockResolvedValue(false)
+
+    const originalIsTTY = process.stdin.isTTY
+    process.stdin.isTTY = true
+
+    const program = createProgram()
+    await program.parseAsync(['payment_intents', 'delete', 'pi_123'], { from: 'user' })
+
+    expect(mockManager.delete).not.toHaveBeenCalled()
+    expect(log).toHaveBeenCalledWith('Aborted.')
+
+    process.stdin.isTTY = originalIsTTY
+  })
+})
+
+describe('factory: v2 namespace', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('uses v2 namespace for v2 resources', async () => {
+    const v2Manager = { list: vi.fn().mockResolvedValue(asyncGenerator([])) }
+    const v2Client = {
+      v2: { transfers: v2Manager },
+    }
+
+    const { createClient } = await import('../../lib/auth.js')
+    vi.mocked(createClient).mockReturnValue(v2Client as unknown as ReturnType<typeof createClient>)
+
+    const v2Resource: ResourceDef = {
+      name: 'transfers',
+      cliCommand: 'transfers',
+      sdkMethod: 'transfers',
+      sdkNamespace: 'v2',
+      verbs: ['list'],
+      priorityColumns: ['id', 'amount', 'status'],
+      listFlags: [],
+    }
+
+    const program = createProgram(v2Resource)
+    await program.parseAsync(['transfers', 'list'], { from: 'user' })
+
+    expect(v2Manager.list).toHaveBeenCalled()
+  })
+})

--- a/src/resources/__tests__/registry.test.ts
+++ b/src/resources/__tests__/registry.test.ts
@@ -33,20 +33,20 @@ describe('resource registry', () => {
 
   test('verbs are valid', () => {
     const validVerbs = new Set(['create', 'get', 'list', 'delete'])
-    for (const resource of resources) {
-      for (const verb of resource.verbs) {
+    resources.forEach((resource) => {
+      resource.verbs.forEach((verb) => {
         expect(validVerbs.has(verb)).toBe(true)
-      }
-    }
+      })
+    })
   })
 
   test('resources with create verb have createFlags', () => {
-    for (const resource of resources) {
-      if (resource.verbs.includes('create')) {
+    resources
+      .filter((resource) => resource.verbs.includes('create'))
+      .forEach((resource) => {
         expect(resource.createFlags).toBeDefined()
         expect(resource.createFlags!.length).toBeGreaterThan(0)
-      }
-    }
+      })
   })
 
   test('createFlags with required=true exist for resources that need them', () => {

--- a/src/resources/factory.ts
+++ b/src/resources/factory.ts
@@ -1,0 +1,256 @@
+import type { Command } from 'commander'
+import type { Fintoc } from 'fintoc'
+import type { FlagDef, ResourceDef } from '../types.js'
+import { confirm } from '@inquirer/prompts'
+import { createClient, resolveAuth } from '../lib/auth.js'
+import { readConfig } from '../lib/config.js'
+import { error, log, printDetail, printJson, printTable, success } from '../lib/output.js'
+
+// Convert kebab-case flag name to camelCase for SDK
+const toCamelCase = (str: string): string =>
+  str.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase())
+
+// Convert kebab-case flag name to snake_case for SDK
+const toSnakeCase = (str: string): string => str.replace(/-/g, '_')
+
+// Get the SDK manager for a resource
+
+const getManager = (
+  client: Fintoc,
+  resource: ResourceDef,
+): Record<string, (...args: unknown[]) => Promise<unknown>> => {
+  const base =
+    resource.sdkNamespace === 'v2' ? (client as unknown as Record<string, unknown>).v2 : client
+  return (base as Record<string, unknown>)[resource.sdkMethod] as Record<
+    string,
+    (...args: unknown[]) => Promise<unknown>
+  >
+}
+
+// Parse flag value according to its type
+const parseFlagValue = (value: string, flag: FlagDef): unknown => {
+  if (flag.type === 'number') return Number(value)
+  if (flag.type === 'boolean') return value === 'true'
+  if (flag.type === 'string[]') return value.split(',').map((s) => s.trim())
+  return value
+}
+
+// Add Commander options from flag definitions
+const addFlags = (cmd: Command, flags: FlagDef[]): void => {
+  for (const flag of flags) {
+    const flagName = `--${flag.name} <${flag.type === 'string[]' ? 'values' : flag.type}>`
+    const desc = flag.description ?? ''
+    const fullDesc = flag.required ? `${desc} (required)` : desc
+    cmd.option(flagName, fullDesc)
+  }
+}
+
+// Collect only explicitly-set option values (skip Commander defaults)
+const collectSetOptions = (cmd: Command, flags: FlagDef[]): Record<string, unknown> => {
+  const opts = cmd.opts()
+  const result: Record<string, unknown> = {}
+
+  for (const flag of flags) {
+    const camelName = toCamelCase(flag.name)
+    if (opts[camelName] !== undefined) {
+      const snakeName = toSnakeCase(flag.name)
+      result[snakeName] = parseFlagValue(String(opts[camelName]), flag)
+    }
+  }
+
+  return result
+}
+
+// Validate required flags are present
+const validateRequired = (
+  cmd: Command,
+  flags: FlagDef[],
+  resourceName: string,
+  verb: string,
+): boolean => {
+  const opts = cmd.opts()
+  const missing = flags
+    .filter((f) => f.required && opts[toCamelCase(f.name)] === undefined)
+    .map((f) => `--${f.name}`)
+
+  if (missing.length > 0) {
+    error(`Missing required ${missing.length === 1 ? 'flag' : 'flags'}: ${missing.join(', ')}`)
+    log('')
+    log(
+      `  Usage: fintoc ${resourceName} ${verb} ${flags
+        .filter((f) => f.required)
+        .map((f) => `--${f.name} <${f.type}>`)
+        .join(' ')}`,
+    )
+    log(`  Help:  fintoc ${resourceName} ${verb} --help`)
+    process.exit(1)
+  }
+
+  return true
+}
+
+// Resolve auth + create SDK client, handling errors
+const resolveClient = (parentOpts: {
+  apiKey?: string
+}): { client: Fintoc; jwsPrivateKey?: string } => {
+  const auth = resolveAuth(parentOpts)
+  const config = readConfig()
+  const jwsPrivateKey = config.jws_private_key
+  const client = createClient(auth.secretKey, jwsPrivateKey)
+  return { client, jwsPrivateKey }
+}
+
+// Serialize SDK resource object to plain object
+const serialize = (obj: unknown): Record<string, unknown> => {
+  if (
+    typeof obj === 'object' &&
+    obj !== null &&
+    'serialize' in obj &&
+    typeof obj.serialize === 'function'
+  ) {
+    return obj.serialize() as Record<string, unknown>
+  }
+  if (typeof obj === 'object' && obj !== null) return { ...obj } as Record<string, unknown>
+  return {}
+}
+
+const registerCreate = (parent: Command, resource: ResourceDef): void => {
+  const cmd = parent
+    .command('create')
+    .description(`Create a new ${resource.name.replace(/_/g, ' ').replace(/s$/, '')}`)
+
+  addFlags(cmd, resource.createFlags ?? [])
+
+  cmd.action(async (_opts: unknown, actionCmd: Command) => {
+    const parentOpts = actionCmd.parent!.parent!.opts<{ apiKey?: string; json?: boolean }>()
+    validateRequired(actionCmd, resource.createFlags ?? [], resource.cliCommand, 'create')
+
+    const body = collectSetOptions(actionCmd, resource.createFlags ?? [])
+    const { client } = resolveClient(parentOpts)
+    const manager = getManager(client, resource)
+
+    const result = await manager.create(body)
+    const data = serialize(result)
+
+    if (parentOpts.json) {
+      printJson(data)
+    } else {
+      success(`${resource.name.replace(/_/g, ' ').replace(/s$/, '')} created`)
+      log('')
+      printDetail(data, resource.priorityColumns)
+    }
+  })
+}
+
+const registerGet = (parent: Command, resource: ResourceDef): void => {
+  parent
+    .command('get <id>')
+    .description(`Get a ${resource.name.replace(/_/g, ' ').replace(/s$/, '')} by ID`)
+    .action(async (id: string, _opts: unknown, actionCmd: Command) => {
+      const parentOpts = actionCmd.parent!.parent!.opts<{ apiKey?: string; json?: boolean }>()
+      const { client } = resolveClient(parentOpts)
+      const manager = getManager(client, resource)
+
+      const result = await manager.get(id)
+      const data = serialize(result)
+
+      if (parentOpts.json) {
+        printJson(data)
+      } else {
+        printDetail(data, resource.priorityColumns)
+      }
+    })
+}
+
+const registerList = (parent: Command, resource: ResourceDef): void => {
+  const cmd = parent
+    .command('list')
+    .description(`List ${resource.name.replace(/_/g, ' ')}`)
+    .option('--limit <number>', 'Max results to show', '10')
+
+  addFlags(cmd, resource.listFlags ?? [])
+
+  cmd.action(async (_opts: unknown, actionCmd: Command) => {
+    const parentOpts = actionCmd.parent!.parent!.opts<{ apiKey?: string; json?: boolean }>()
+    const localOpts = actionCmd.opts<{ limit: string }>()
+    const limit = Number(localOpts.limit)
+    if (Number.isNaN(limit) || limit <= 0) {
+      error('--limit must be a positive number')
+      process.exit(1)
+    }
+
+    const filters = collectSetOptions(actionCmd, resource.listFlags ?? [])
+    const { client } = resolveClient(parentOpts)
+    const manager = getManager(client, resource)
+
+    const generator = (await manager.list({ ...filters, lazy: true })) as AsyncIterable<unknown>
+    const items: Record<string, unknown>[] = []
+
+    for await (const item of generator) {
+      items.push(serialize(item))
+      if (items.length >= limit) break
+    }
+
+    if (parentOpts.json) {
+      printJson(items)
+    } else {
+      printTable({
+        columns: resource.priorityColumns,
+        rows: items,
+      })
+    }
+  })
+}
+
+const registerDelete = (parent: Command, resource: ResourceDef): void => {
+  parent
+    .command('delete <id>')
+    .description(`Delete a ${resource.name.replace(/_/g, ' ').replace(/s$/, '')}`)
+    .option('--yes', 'Skip confirmation prompt')
+    .action(async (id: string, opts: { yes?: boolean }, actionCmd: Command) => {
+      const parentOpts = actionCmd.parent!.parent!.opts<{ apiKey?: string; json?: boolean }>()
+
+      if (!opts.yes) {
+        if (!process.stdin.isTTY) {
+          error(`Confirmation required to delete '${id}'. Use --yes to skip.`)
+          process.exit(1)
+        }
+        const confirmed = await confirm({
+          message: `Are you sure you want to delete '${id}'?`,
+          default: false,
+        })
+        if (!confirmed) {
+          log('Aborted.')
+          return
+        }
+      }
+
+      const { client } = resolveClient(parentOpts)
+      const manager = getManager(client, resource)
+
+      await manager.delete(id)
+      success(`${resource.name.replace(/_/g, ' ').replace(/s$/, '')} '${id}' deleted`)
+    })
+}
+
+const verbRegistrars: Record<string, (parent: Command, resource: ResourceDef) => void> = {
+  create: registerCreate,
+  get: registerGet,
+  list: registerList,
+  delete: registerDelete,
+}
+
+export const registerResourceCommands = (program: Command, resourceDefs: ResourceDef[]): void => {
+  for (const resource of resourceDefs) {
+    const resourceCmd = program
+      .command(resource.cliCommand)
+      .description(`Manage ${resource.name.replace(/_/g, ' ')}`)
+
+    for (const verb of resource.verbs) {
+      const registrar = verbRegistrars[verb]
+      if (registrar) {
+        registrar(resourceCmd, resource)
+      }
+    }
+  }
+}

--- a/src/resources/factory.ts
+++ b/src/resources/factory.ts
@@ -1,34 +1,34 @@
 import type { Command } from 'commander'
 import type { Fintoc } from 'fintoc'
-import type { FlagDef, ResourceDef } from '../types.js'
+import type { FlagDef, ResourceDef, SdkManager, Serializable } from '../types.js'
 import { confirm } from '@inquirer/prompts'
 import { createClient, resolveAuth } from '../lib/auth.js'
 import { readConfig } from '../lib/config.js'
 import { error, log, printDetail, printJson, printTable, success } from '../lib/output.js'
 
+type RootOpts = {
+  apiKey?: string
+  json?: boolean
+}
+
 // Convert kebab-case flag name to camelCase for SDK
-const toCamelCase = (str: string): string =>
-  str.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase())
+const toCamelCase = (str: string) => str.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase())
 
 // Convert kebab-case flag name to snake_case for SDK
-const toSnakeCase = (str: string): string => str.replace(/-/g, '_')
+const toSnakeCase = (str: string) => str.replace(/-/g, '_')
+
+// Get root program opts from a nested action command
+const getRootOpts = (actionCmd: Command) => actionCmd.parent!.parent!.opts<RootOpts>()
 
 // Get the SDK manager for a resource
-
-const getManager = (
-  client: Fintoc,
-  resource: ResourceDef,
-): Record<string, (...args: unknown[]) => Promise<unknown>> => {
+const getManager = (client: Fintoc, resource: ResourceDef) => {
   const base =
     resource.sdkNamespace === 'v2' ? (client as unknown as Record<string, unknown>).v2 : client
-  return (base as Record<string, unknown>)[resource.sdkMethod] as Record<
-    string,
-    (...args: unknown[]) => Promise<unknown>
-  >
+  return (base as Record<string, unknown>)[resource.sdkMethod] as SdkManager
 }
 
 // Parse flag value according to its type
-const parseFlagValue = (value: string, flag: FlagDef): unknown => {
+const parseFlagValue = (value: string, flag: FlagDef) => {
   if (flag.type === 'number') return Number(value)
   if (flag.type === 'boolean') return value === 'true'
   if (flag.type === 'string[]') return value.split(',').map((s) => s.trim())
@@ -36,7 +36,7 @@ const parseFlagValue = (value: string, flag: FlagDef): unknown => {
 }
 
 // Add Commander options from flag definitions
-const addFlags = (cmd: Command, flags: FlagDef[]): void => {
+const addFlags = (cmd: Command, flags: FlagDef[]) => {
   for (const flag of flags) {
     const flagName = `--${flag.name} <${flag.type === 'string[]' ? 'values' : flag.type}>`
     const desc = flag.description ?? ''
@@ -46,7 +46,7 @@ const addFlags = (cmd: Command, flags: FlagDef[]): void => {
 }
 
 // Collect only explicitly-set option values (skip Commander defaults)
-const collectSetOptions = (cmd: Command, flags: FlagDef[]): Record<string, unknown> => {
+const collectSetOptions = (cmd: Command, flags: FlagDef[]) => {
   const opts = cmd.opts()
   const result: Record<string, unknown> = {}
 
@@ -62,12 +62,7 @@ const collectSetOptions = (cmd: Command, flags: FlagDef[]): Record<string, unkno
 }
 
 // Validate required flags are present
-const validateRequired = (
-  cmd: Command,
-  flags: FlagDef[],
-  resourceName: string,
-  verb: string,
-): boolean => {
+const validateRequired = (cmd: Command, flags: FlagDef[], resourceName: string, verb: string) => {
   const opts = cmd.opts()
   const missing = flags
     .filter((f) => f.required && opts[toCamelCase(f.name)] === undefined)
@@ -85,14 +80,10 @@ const validateRequired = (
     log(`  Help:  fintoc ${resourceName} ${verb} --help`)
     process.exit(1)
   }
-
-  return true
 }
 
 // Resolve auth + create SDK client, handling errors
-const resolveClient = (parentOpts: {
-  apiKey?: string
-}): { client: Fintoc; jwsPrivateKey?: string } => {
+const resolveClient = (parentOpts: RootOpts) => {
   const auth = resolveAuth(parentOpts)
   const config = readConfig()
   const jwsPrivateKey = config.jws_private_key
@@ -100,61 +91,61 @@ const resolveClient = (parentOpts: {
   return { client, jwsPrivateKey }
 }
 
+// Type predicate for SDK objects with a serialize() method
+const isSerializable = (obj: unknown): obj is Serializable =>
+  typeof obj === 'object' &&
+  obj !== null &&
+  'serialize' in obj &&
+  typeof obj.serialize === 'function'
+
 // Serialize SDK resource object to plain object
 const serialize = (obj: unknown): Record<string, unknown> => {
-  if (
-    typeof obj === 'object' &&
-    obj !== null &&
-    'serialize' in obj &&
-    typeof obj.serialize === 'function'
-  ) {
-    return obj.serialize() as Record<string, unknown>
-  }
+  if (isSerializable(obj)) return obj.serialize()
   if (typeof obj === 'object' && obj !== null) return { ...obj } as Record<string, unknown>
   return {}
 }
 
-const registerCreate = (parent: Command, resource: ResourceDef): void => {
-  const cmd = parent
-    .command('create')
-    .description(`Create a new ${resource.name.replace(/_/g, ' ').replace(/s$/, '')}`)
+const registerCreate = (parent: Command, resource: ResourceDef) => {
+  const cmd = parent.command('create').description(`Create a new ${resource.displayName}`)
 
   addFlags(cmd, resource.createFlags ?? [])
 
   cmd.action(async (_opts: unknown, actionCmd: Command) => {
-    const parentOpts = actionCmd.parent!.parent!.opts<{ apiKey?: string; json?: boolean }>()
+    const rootOpts = getRootOpts(actionCmd)
     validateRequired(actionCmd, resource.createFlags ?? [], resource.cliCommand, 'create')
 
     const body = collectSetOptions(actionCmd, resource.createFlags ?? [])
-    const { client } = resolveClient(parentOpts)
+    const { client } = resolveClient(rootOpts)
     const manager = getManager(client, resource)
 
+    if (!manager.create) throw new Error(`${resource.name} does not support create`)
     const result = await manager.create(body)
     const data = serialize(result)
 
-    if (parentOpts.json) {
+    if (rootOpts.json) {
       printJson(data)
     } else {
-      success(`${resource.name.replace(/_/g, ' ').replace(/s$/, '')} created`)
+      success(`${resource.displayName} created`)
       log('')
       printDetail(data, resource.priorityColumns)
     }
   })
 }
 
-const registerGet = (parent: Command, resource: ResourceDef): void => {
+const registerGet = (parent: Command, resource: ResourceDef) => {
   parent
     .command('get <id>')
-    .description(`Get a ${resource.name.replace(/_/g, ' ').replace(/s$/, '')} by ID`)
+    .description(`Get a ${resource.displayName} by ID`)
     .action(async (id: string, _opts: unknown, actionCmd: Command) => {
-      const parentOpts = actionCmd.parent!.parent!.opts<{ apiKey?: string; json?: boolean }>()
-      const { client } = resolveClient(parentOpts)
+      const rootOpts = getRootOpts(actionCmd)
+      const { client } = resolveClient(rootOpts)
       const manager = getManager(client, resource)
 
+      if (!manager.get) throw new Error(`${resource.name} does not support get`)
       const result = await manager.get(id)
       const data = serialize(result)
 
-      if (parentOpts.json) {
+      if (rootOpts.json) {
         printJson(data)
       } else {
         printDetail(data, resource.priorityColumns)
@@ -162,7 +153,7 @@ const registerGet = (parent: Command, resource: ResourceDef): void => {
     })
 }
 
-const registerList = (parent: Command, resource: ResourceDef): void => {
+const registerList = (parent: Command, resource: ResourceDef) => {
   const cmd = parent
     .command('list')
     .description(`List ${resource.name.replace(/_/g, ' ')}`)
@@ -171,7 +162,7 @@ const registerList = (parent: Command, resource: ResourceDef): void => {
   addFlags(cmd, resource.listFlags ?? [])
 
   cmd.action(async (_opts: unknown, actionCmd: Command) => {
-    const parentOpts = actionCmd.parent!.parent!.opts<{ apiKey?: string; json?: boolean }>()
+    const rootOpts = getRootOpts(actionCmd)
     const localOpts = actionCmd.opts<{ limit: string }>()
     const limit = Number(localOpts.limit)
     if (Number.isNaN(limit) || limit <= 0) {
@@ -180,9 +171,10 @@ const registerList = (parent: Command, resource: ResourceDef): void => {
     }
 
     const filters = collectSetOptions(actionCmd, resource.listFlags ?? [])
-    const { client } = resolveClient(parentOpts)
+    const { client } = resolveClient(rootOpts)
     const manager = getManager(client, resource)
 
+    if (!manager.list) throw new Error(`${resource.name} does not support list`)
     const generator = (await manager.list({ ...filters, lazy: true })) as AsyncIterable<unknown>
     const items: Record<string, unknown>[] = []
 
@@ -191,7 +183,7 @@ const registerList = (parent: Command, resource: ResourceDef): void => {
       if (items.length >= limit) break
     }
 
-    if (parentOpts.json) {
+    if (rootOpts.json) {
       printJson(items)
     } else {
       printTable({
@@ -202,13 +194,13 @@ const registerList = (parent: Command, resource: ResourceDef): void => {
   })
 }
 
-const registerDelete = (parent: Command, resource: ResourceDef): void => {
+const registerDelete = (parent: Command, resource: ResourceDef) => {
   parent
     .command('delete <id>')
-    .description(`Delete a ${resource.name.replace(/_/g, ' ').replace(/s$/, '')}`)
+    .description(`Delete a ${resource.displayName}`)
     .option('--yes', 'Skip confirmation prompt')
     .action(async (id: string, opts: { yes?: boolean }, actionCmd: Command) => {
-      const parentOpts = actionCmd.parent!.parent!.opts<{ apiKey?: string; json?: boolean }>()
+      const rootOpts = getRootOpts(actionCmd)
 
       if (!opts.yes) {
         if (!process.stdin.isTTY) {
@@ -225,23 +217,28 @@ const registerDelete = (parent: Command, resource: ResourceDef): void => {
         }
       }
 
-      const { client } = resolveClient(parentOpts)
+      const { client } = resolveClient(rootOpts)
       const manager = getManager(client, resource)
 
+      if (!manager.delete) throw new Error(`${resource.name} does not support delete`)
       await manager.delete(id)
-      success(`${resource.name.replace(/_/g, ' ').replace(/s$/, '')} '${id}' deleted`)
+      success(`${resource.displayName} '${id}' deleted`)
     })
 }
 
-const verbRegistrars: Record<string, (parent: Command, resource: ResourceDef) => void> = {
+const verbRegistrars = {
   create: registerCreate,
   get: registerGet,
   list: registerList,
   delete: registerDelete,
-}
+} satisfies Record<string, (parent: Command, resource: ResourceDef) => void>
 
-export const registerResourceCommands = (program: Command, resourceDefs: ResourceDef[]): void => {
+export const registerResourceCommands = (program: Command, resourceDefs: ResourceDef[]) => {
   for (const resource of resourceDefs) {
+    if (resource.verbs.includes('create') && !resource.createFlags?.length) {
+      throw new Error(`Resource ${resource.name} has 'create' verb but no createFlags`)
+    }
+
     const resourceCmd = program
       .command(resource.cliCommand)
       .description(`Manage ${resource.name.replace(/_/g, ' ')}`)

--- a/src/resources/factory.ts
+++ b/src/resources/factory.ts
@@ -82,13 +82,12 @@ const validateRequired = (cmd: Command, flags: FlagDef[], resourceName: string, 
   }
 }
 
-// Resolve auth + create SDK client, handling errors
-const resolveClient = (parentOpts: RootOpts) => {
+// Resolve auth + create SDK client, reading JWS only when the resource requires it
+const resolveClient = (parentOpts: RootOpts, resource: ResourceDef) => {
   const auth = resolveAuth(parentOpts)
-  const config = readConfig()
-  const jwsPrivateKey = config.jws_private_key
+  const jwsPrivateKey = resource.needsJws ? readConfig().jws_private_key : undefined
   const client = createClient(auth.secretKey, jwsPrivateKey)
-  return { client, jwsPrivateKey }
+  return { client }
 }
 
 // Type predicate for SDK objects with a serialize() method
@@ -115,7 +114,7 @@ const registerCreate = (parent: Command, resource: ResourceDef) => {
     validateRequired(actionCmd, resource.createFlags ?? [], resource.cliCommand, 'create')
 
     const body = collectSetOptions(actionCmd, resource.createFlags ?? [])
-    const { client } = resolveClient(rootOpts)
+    const { client } = resolveClient(rootOpts, resource)
     const manager = getManager(client, resource)
 
     if (!manager.create) throw new Error(`${resource.name} does not support create`)
@@ -138,7 +137,7 @@ const registerGet = (parent: Command, resource: ResourceDef) => {
     .description(`Get a ${resource.displayName} by ID`)
     .action(async (id: string, _opts: unknown, actionCmd: Command) => {
       const rootOpts = getRootOpts(actionCmd)
-      const { client } = resolveClient(rootOpts)
+      const { client } = resolveClient(rootOpts, resource)
       const manager = getManager(client, resource)
 
       if (!manager.get) throw new Error(`${resource.name} does not support get`)
@@ -171,7 +170,7 @@ const registerList = (parent: Command, resource: ResourceDef) => {
     }
 
     const filters = collectSetOptions(actionCmd, resource.listFlags ?? [])
-    const { client } = resolveClient(rootOpts)
+    const { client } = resolveClient(rootOpts, resource)
     const manager = getManager(client, resource)
 
     if (!manager.list) throw new Error(`${resource.name} does not support list`)
@@ -217,7 +216,7 @@ const registerDelete = (parent: Command, resource: ResourceDef) => {
         }
       }
 
-      const { client } = resolveClient(rootOpts)
+      const { client } = resolveClient(rootOpts, resource)
       const manager = getManager(client, resource)
 
       if (!manager.delete) throw new Error(`${resource.name} does not support delete`)
@@ -234,7 +233,7 @@ const verbRegistrars = {
 } satisfies Record<string, (parent: Command, resource: ResourceDef) => void>
 
 export const registerResourceCommands = (program: Command, resourceDefs: ResourceDef[]) => {
-  for (const resource of resourceDefs) {
+  resourceDefs.forEach((resource) => {
     if (resource.verbs.includes('create') && !resource.createFlags?.length) {
       throw new Error(`Resource ${resource.name} has 'create' verb but no createFlags`)
     }
@@ -243,11 +242,8 @@ export const registerResourceCommands = (program: Command, resourceDefs: Resourc
       .command(resource.cliCommand)
       .description(`Manage ${resource.name.replace(/_/g, ' ')}`)
 
-    for (const verb of resource.verbs) {
-      const registrar = verbRegistrars[verb]
-      if (registrar) {
-        registrar(resourceCmd, resource)
-      }
-    }
-  }
+    resource.verbs.forEach((verb) => {
+      verbRegistrars[verb]?.(resourceCmd, resource)
+    })
+  })
 }

--- a/src/resources/registry.ts
+++ b/src/resources/registry.ts
@@ -53,6 +53,7 @@ export const resources: ResourceDef[] = [
     sdkMethod: 'transfers',
     sdkNamespace: 'v2',
     verbs: ['create', 'get', 'list'],
+    needsJws: true,
     priorityColumns: ['id', 'amount', 'currency', 'status', 'created_at'],
     createFlags: [
       {

--- a/src/resources/registry.ts
+++ b/src/resources/registry.ts
@@ -3,6 +3,7 @@ import type { ResourceDef } from '../types.js'
 export const resources: ResourceDef[] = [
   {
     name: 'payment_intents',
+    displayName: 'payment intent',
     cliCommand: 'payment_intents',
     sdkMethod: 'paymentIntents',
     sdkNamespace: 'v1',
@@ -47,6 +48,7 @@ export const resources: ResourceDef[] = [
   },
   {
     name: 'transfers',
+    displayName: 'transfer',
     cliCommand: 'transfers',
     sdkMethod: 'transfers',
     sdkNamespace: 'v2',
@@ -92,6 +94,7 @@ export const resources: ResourceDef[] = [
   },
   {
     name: 'accounts',
+    displayName: 'account',
     cliCommand: 'accounts',
     sdkMethod: 'accounts',
     sdkNamespace: 'v2',
@@ -101,6 +104,7 @@ export const resources: ResourceDef[] = [
   },
   {
     name: 'webhook_endpoints',
+    displayName: 'webhook endpoint',
     cliCommand: 'webhook_endpoints',
     sdkMethod: 'webhookEndpoints',
     sdkNamespace: 'v1',
@@ -125,6 +129,7 @@ export const resources: ResourceDef[] = [
   },
   {
     name: 'charges',
+    displayName: 'charge',
     cliCommand: 'charges',
     sdkMethod: 'charges',
     sdkNamespace: 'v1',
@@ -169,6 +174,7 @@ export const resources: ResourceDef[] = [
   },
   {
     name: 'subscriptions',
+    displayName: 'subscription',
     cliCommand: 'subscriptions',
     sdkMethod: 'subscriptions',
     sdkNamespace: 'v1',
@@ -189,6 +195,7 @@ export const resources: ResourceDef[] = [
   },
   {
     name: 'links',
+    displayName: 'link',
     cliCommand: 'links',
     sdkMethod: 'links',
     sdkNamespace: 'v1',
@@ -204,6 +211,7 @@ export const resources: ResourceDef[] = [
   },
   {
     name: 'api_keys',
+    displayName: 'API key',
     cliCommand: 'api_keys',
     sdkMethod: 'apiKeys',
     sdkNamespace: 'v1',

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export type FlagDef = {
 
 export type ResourceDef = {
   name: string
+  displayName: string
   cliCommand: string
   sdkMethod: string
   sdkNamespace: 'v1' | 'v2'
@@ -23,4 +24,15 @@ export type ResourceDef = {
   priorityColumns: string[]
   createFlags?: FlagDef[]
   listFlags?: FlagDef[]
+}
+
+export type SdkManager = {
+  create?: (body: Record<string, unknown>) => Promise<unknown>
+  get?: (id: string) => Promise<unknown>
+  list?: (params: Record<string, unknown>) => Promise<unknown>
+  delete?: (id: string) => Promise<unknown>
+}
+
+export type Serializable = {
+  serialize: () => Record<string, unknown>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export type ResourceDef = {
   sdkMethod: string
   sdkNamespace: 'v1' | 'v2'
   verbs: Verb[]
+  needsJws?: boolean
   priorityColumns: string[]
   createFlags?: FlagDef[]
   listFlags?: FlagDef[]


### PR DESCRIPTION
## Contexto

Factory que genera automáticamente subcomandos CRUD para los 8 recursos del registry, junto con output formatting (tablas, colores, JSON).

## Cambios

- [x] `output.ts` — Table rendering, status coloreado, modo `--json`, `printDetail`
- [x] `factory.ts` — `registerResourceCommands()` genera `create`/`get`/`list`/`delete` desde `ResourceDef[]`
- [x] `index.ts` — Flags globales `--api-key` y `--json`, wiring del factory
- [x] Tests unitarios (78 tests passing)

<sup>*Created with Claude Code `/create-pr` command*</sup>