### PR TITLE
[ONB-1784] Sistema de error handling con next-steps

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Contexto
+¿Por qué?
+
+Agregar un pequeño resumen que de contexto y explique porque es importante el cambio
+que se está proponiendo.
+
+## Que hay de nuevo?
+¿Qué?
+
+Resumen que explique que es lo que se implementó concretamente. Un punteo
+de cambios específicos también es bienvenido.
+
+- [x] Endpoint para exponer x
+- [x] Se elimina configuración y
+- [x] Clase Z
+
+## Tests
+¿Como nos aseguramos de que esto funciona?
+
+- [x] Tests unitarios para x
+- [x] Tests de integración entre x e y
+
+## Consideraciones
+Cosas generales que el reviewer debería tener en cuenta. Pueden ser componentes
+que se ven afectados por el PR, decisiones que se tomaron para el desarrollo,
+dudas para discutir con los reviewers, cosas que quedaron fuera de scope, etc.
+
+Ej.
+- Se decidió separar x funcionalidad en dos endpoints
+- ¿Les parece bien este nombre para y?
+- Se decidió no incluir el refactor de x en este PR

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -27,12 +27,37 @@ export default antfu(
           semi: false,
         },
       ],
+      // TypeScript
       'ts/no-explicit-any': 'error',
       'ts/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
       'ts/consistent-type-imports': 'error',
       'ts/consistent-type-definitions': ['error', 'type'],
+      'ts/ban-ts-comment': 'error',
+      'ts/no-non-null-asserted-optional-chain': 'error',
+
+      // Code quality
       'no-console': 'error',
+      curly: ['error', 'all'],
+      'consistent-return': 'error',
+      'no-constant-binary-expression': 'error',
+      'no-constant-condition': 'error',
+      'no-param-reassign': ['error', { props: true }],
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'vitest',
+              importNames: ['it'],
+              message: "Please use 'test' instead.",
+            },
+          ],
+        },
+      ],
       'node/prefer-global/process': 'off',
+
+      // Test
+      'test/prefer-lowercase-title': 'off',
       'test/consistent-test-it': ['error', { fn: 'test', withinDescribe: 'test' }],
     },
   },

--- a/src/commands/__tests__/login.test.ts
+++ b/src/commands/__tests__/login.test.ts
@@ -96,7 +96,7 @@ describe('login command', () => {
     await expect(program.parseAsync(['login'], { from: 'user' })).rejects.toThrow('process.exit')
 
     expect(writeConfig).not.toHaveBeenCalled()
-    expect(error).toHaveBeenCalledWith('Authentication failed: Invalid API key')
+    expect(error).toHaveBeenCalledWith('Invalid API key')
 
     exitSpy.mockRestore()
   })

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -4,6 +4,7 @@ import { password } from '@inquirer/prompts'
 
 import { whoami } from '../lib/auth.js'
 import { CONFIG_PATH, readConfig, writeConfig } from '../lib/config.js'
+import { handleError } from '../lib/errors.js'
 import { error, log, success } from '../lib/output.js'
 
 export const loginCommand = (program: Command) => {
@@ -43,12 +44,7 @@ export const loginCommand = (program: Command) => {
         success(`Authenticated as ${info.organizationName} (${info.mode} mode)`)
         log(`  Key stored in ${CONFIG_PATH}`)
       } catch (err) {
-        const message = err instanceof Error ? err.message : 'Unknown error'
-        error(`Authentication failed: ${message}`)
-        log('')
-        log('  Check your API key and try again.')
-        log('  Get your API keys at: https://dashboard.fintoc.com/api-keys')
-        process.exit(1)
+        handleError(err)
       }
     })
 }

--- a/src/lib/__tests__/errors.test.ts
+++ b/src/lib/__tests__/errors.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { handleError } from '../errors.js'
+import { error, log } from '../output.js'
+
+vi.mock('../output.js', () => ({
+  log: vi.fn(),
+  error: vi.fn(),
+}))
+
+// Helper to create a FintocError-like error with a specific constructor name.
+// The SDK builds messages as: "type[: code][ (param)]\nmessage"
+const createFintocError = (
+  name: string,
+  { type, code, param, message }: { type: string; code?: string; param?: string; message: string },
+) => {
+  let msg = type
+  if (code) {
+    msg += `: ${code}`
+  }
+  if (param) {
+    msg += ` (${param})`
+  }
+  msg += `\n${message}`
+  const err = new Error(msg)
+  Object.defineProperty(err, 'constructor', { value: { name } })
+  return err
+}
+
+// Helper to create a connectivity error (Axios-style)
+const createNetworkError = (code: string) => {
+  const err = new Error(`connect ${code}`)
+  ;(err as unknown as Record<string, string>).code = code
+  return err
+}
+
+describe('handleError', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit')
+    })
+  })
+
+  afterEach(() => {
+    exitSpy.mockRestore()
+  })
+
+  describe('no API key', () => {
+    test('formats no-auth error with next steps', () => {
+      const err = new Error(
+        'No API key found. To authenticate:\n\n  Run:   fintoc login\n  Or:    export FINTOC_SECRET_KEY=sk_test_...',
+      )
+
+      expect(() => handleError(err)).toThrow('process.exit')
+
+      expect(error).toHaveBeenCalledWith('No API key found. To authenticate:')
+      expect(log).toHaveBeenCalledWith('  Run:   fintoc login')
+      expect(log).toHaveBeenCalledWith(
+        '  Get your API keys at: https://dashboard.fintoc.com/api-keys',
+      )
+      expect(exitSpy).toHaveBeenCalledWith(1)
+    })
+  })
+
+  describe('connectivity errors', () => {
+    test.each(['ECONNREFUSED', 'ENOTFOUND', 'ETIMEDOUT', 'ECONNRESET', 'ERR_NETWORK'])(
+      'formats %s as connectivity error',
+      (code) => {
+        const err = createNetworkError(code)
+
+        expect(() => handleError(err)).toThrow('process.exit')
+
+        expect(error).toHaveBeenCalledWith('Could not connect to api.fintoc.com')
+        expect(log).toHaveBeenCalledWith('  Check your internet connection, or run: fintoc doctor')
+      },
+    )
+  })
+
+  describe('missing JWS key', () => {
+    test('formats JWS-related error with next steps', () => {
+      const err = new Error('JWS private key is required')
+
+      expect(() => handleError(err)).toThrow('process.exit')
+
+      expect(error).toHaveBeenCalledWith('JWS private key required for transfer operations')
+      expect(log).toHaveBeenCalledWith('  More info:    https://docs.fintoc.com/docs/transfers')
+    })
+  })
+
+  describe('not found (404)', () => {
+    test('formats not found error with resource context', () => {
+      const err = createFintocError('InvalidRequestError', {
+        type: 'invalid_request_error',
+        code: 'missing_resource',
+        param: 'id',
+        message: 'No such payment_intent: pi_invalid',
+      })
+
+      expect(() =>
+        handleError(err, { resourceName: 'payment_intents', verb: 'get', id: 'pi_invalid' }),
+      ).toThrow('process.exit')
+
+      expect(error).toHaveBeenCalledWith("Error (404): 'pi_invalid' not found")
+      expect(log).toHaveBeenCalledWith('  List available: fintoc payment_intents list')
+    })
+
+    test('formats not found error without ID', () => {
+      const err = createFintocError('InvalidRequestError', {
+        type: 'invalid_request_error',
+        code: 'missing_resource',
+        param: 'id',
+        message: 'No such payment_intent: pi_invalid',
+      })
+
+      expect(() => handleError(err, { resourceName: 'payment_intents', verb: 'get' })).toThrow(
+        'process.exit',
+      )
+
+      expect(error).toHaveBeenCalledWith('Error (404): Resource not found')
+    })
+  })
+
+  describe('authentication error', () => {
+    test('formats AuthenticationError with next steps', () => {
+      const err = createFintocError('AuthenticationError', {
+        type: 'authentication_error',
+        message: 'Invalid API key',
+      })
+
+      expect(() => handleError(err)).toThrow('process.exit')
+
+      expect(error).toHaveBeenCalledWith('Authentication failed: Invalid API key')
+      expect(log).toHaveBeenCalledWith('  Check your API key and try again.')
+      expect(log).toHaveBeenCalledWith(
+        '  Get your API keys at: https://dashboard.fintoc.com/api-keys',
+      )
+    })
+  })
+
+  describe('other Fintoc API errors', () => {
+    test('formats generic FintocError with its human-readable message', () => {
+      const err = createFintocError('InvalidRequestError', {
+        type: 'invalid_request_error',
+        code: 'parameter_invalid_integer',
+        param: 'amount',
+        message: 'This value must be a positive integer.',
+      })
+
+      expect(() => handleError(err)).toThrow('process.exit')
+
+      expect(error).toHaveBeenCalledWith('This value must be a positive integer.')
+    })
+  })
+
+  describe('unknown errors', () => {
+    test('formats unknown Error with its message', () => {
+      const err = new Error('Something went wrong')
+
+      expect(() => handleError(err)).toThrow('process.exit')
+
+      expect(error).toHaveBeenCalledWith('Something went wrong')
+    })
+
+    test('formats non-Error with fallback message', () => {
+      expect(() => handleError('string error')).toThrow('process.exit')
+
+      expect(error).toHaveBeenCalledWith('An unexpected error occurred')
+    })
+
+    test('formats null error with fallback message', () => {
+      expect(() => handleError(null)).toThrow('process.exit')
+
+      expect(error).toHaveBeenCalledWith('An unexpected error occurred')
+    })
+  })
+
+  describe('process.exit', () => {
+    test('always exits with code 1', () => {
+      const err = new Error('any error')
+
+      expect(() => handleError(err)).toThrow('process.exit')
+
+      expect(exitSpy).toHaveBeenCalledWith(1)
+    })
+  })
+})

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -17,7 +17,9 @@ export const readConfig = (): FintocConfig => {
     const content = readFileSync(CONFIG_PATH, 'utf-8')
     return parse(content) as FintocConfig
   } catch (err) {
-    if (isFileNotFound(err)) return {}
+    if (isFileNotFound(err)) {
+      return {}
+    }
     throw err
   }
 }
@@ -34,7 +36,9 @@ export const clearConfig = () => {
   try {
     unlinkSync(CONFIG_PATH)
   } catch (err) {
-    if (isFileNotFound(err)) return
+    if (isFileNotFound(err)) {
+      return
+    }
     throw err
   }
 }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,154 @@
+import { error, log } from './output.js'
+
+type ErrorContext = {
+  resourceName?: string
+  verb?: string
+  id?: string
+}
+
+// Parsed fields from a FintocError message.
+// The SDK builds messages as: "type[: code][ (param)]\nmessage[\nCheck the docs...]"
+type FintocErrorFields = {
+  type: string
+  code?: string
+  param?: string
+  message?: string
+}
+
+const CONNECTIVITY_CODES = new Set([
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'ETIMEDOUT',
+  'ECONNRESET',
+  'ERR_NETWORK',
+])
+
+// Detect FintocError subclasses by constructor name (not exported from SDK)
+const FINTOC_ERROR_CLASSES = new Set([
+  'FintocError',
+  'ApiError',
+  'AuthenticationError',
+  'LinkError',
+  'InstitutionError',
+  'InvalidRequestError',
+])
+
+const isFintocError = (err: unknown): err is Error =>
+  err instanceof Error && FINTOC_ERROR_CLASSES.has(err.constructor.name)
+
+// Parse structured fields from a FintocError message.
+// Format: "type[: code][ (param)]\nmessage[\nCheck the docs for more info: url]"
+const parseFintocError = (err: unknown): FintocErrorFields | undefined => {
+  if (!isFintocError(err)) {
+    return undefined
+  }
+
+  const lines = err.message.split('\n')
+  const firstLine = lines[0] ?? ''
+
+  // Parse "type[: code][ (param)]"
+  const match = firstLine.match(/^(\w+)(?::\s*(\w+))?(?:\s*\((\w+)\))?$/)
+  if (!match) {
+    return { type: firstLine }
+  }
+
+  return {
+    type: match[1],
+    code: match[2],
+    param: match[3],
+    message: lines[1],
+  }
+}
+
+// Detect "No API key" error thrown by resolveAuth
+const isNoAuthError = (err: unknown): boolean =>
+  err instanceof Error && err.message.includes('No API key found')
+
+// Detect network/connectivity errors (Axios errors without a response)
+const isConnectivityError = (err: unknown): boolean => {
+  if (!(err instanceof Error)) {
+    return false
+  }
+  const code = (err as { code?: string }).code
+  return typeof code === 'string' && CONNECTIVITY_CODES.has(code)
+}
+
+const isJwsMissingError = (err: unknown): boolean => {
+  if (!(err instanceof Error)) {
+    return false
+  }
+  const msg = err.message.toLowerCase()
+  return msg.includes('jws private key') || msg.includes('jws_private_key')
+}
+
+const printNextSteps = (steps: string[]) => {
+  log('')
+  steps.forEach((step) => log(`  ${step}`))
+}
+
+export const handleError = (err: unknown, context?: ErrorContext): never => {
+  // No API key configured
+  if (isNoAuthError(err)) {
+    error('No API key found. To authenticate:')
+    printNextSteps([
+      'Run:   fintoc login',
+      'Or:    export FINTOC_SECRET_KEY=sk_test_...',
+      'Or:    fintoc --api-key sk_test_... <command>',
+      '',
+      'Get your API keys at: https://dashboard.fintoc.com/api-keys',
+    ])
+    return process.exit(1)
+  }
+
+  // Network / connectivity failure
+  if (isConnectivityError(err)) {
+    error('Could not connect to api.fintoc.com')
+    printNextSteps(['Check your internet connection, or run: fintoc doctor'])
+    return process.exit(1)
+  }
+
+  // JWS private key missing (for transfers)
+  if (isJwsMissingError(err)) {
+    error('JWS private key required for transfer operations')
+    printNextSteps([
+      'Set it with:  fintoc config set jws_private_key <path>',
+      'Or pass:      --jws-private-key <path>',
+      'More info:    https://docs.fintoc.com/docs/transfers',
+    ])
+    return process.exit(1)
+  }
+
+  // Parse structured fields from FintocError
+  const fields = parseFintocError(err)
+
+  if (fields) {
+    // Resource not found (404) — API returns code "missing_resource"
+    if (fields.code === 'missing_resource') {
+      const label = context?.id ? `'${context.id}' not found` : 'Resource not found'
+      error(`Error (404): ${label}`)
+      if (context?.resourceName) {
+        printNextSteps([`List available: fintoc ${context.resourceName} list`])
+      }
+      return process.exit(1)
+    }
+
+    // Authentication error from the API (invalid key, expired, etc.)
+    if (fields.type === 'authentication_error') {
+      error(`Authentication failed: ${fields.message ?? 'Invalid API key'}`)
+      printNextSteps([
+        'Check your API key and try again.',
+        'Get your API keys at: https://dashboard.fintoc.com/api-keys',
+      ])
+      return process.exit(1)
+    }
+
+    // Other Fintoc API errors — show the human-readable message
+    error(fields.message ?? (err as Error).message)
+    return process.exit(1)
+  }
+
+  // Unknown / unexpected errors
+  const message = err instanceof Error ? err.message : 'An unexpected error occurred'
+  error(message)
+  return process.exit(1)
+}

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -39,7 +39,9 @@ const STATUS_COLORS = {
 } satisfies Record<string, (text: string) => string>
 
 export const colorizeStatus = (status: string) => {
-  if (!(status in STATUS_COLORS)) return status
+  if (!(status in STATUS_COLORS)) {
+    return status
+  }
   return STATUS_COLORS[status as keyof typeof STATUS_COLORS](status)
 }
 
@@ -54,10 +56,18 @@ export type TableOptions = {
 }
 
 export const formatValue = (key: string, value: unknown) => {
-  if (value === null || value === undefined) return dim('—')
-  if (key === 'status') return colorizeStatus(String(value))
-  if (value instanceof Date) return value.toISOString().slice(0, 10)
-  if (Array.isArray(value)) return value.join(', ')
+  if (value === null || value === undefined) {
+    return dim('—')
+  }
+  if (key === 'status') {
+    return colorizeStatus(String(value))
+  }
+  if (value instanceof Date) {
+    return value.toISOString().slice(0, 10)
+  }
+  if (Array.isArray(value)) {
+    return value.join(', ')
+  }
   return String(value)
 }
 
@@ -108,12 +118,16 @@ export const printJson = (data: unknown) => {
 
 export const printDetail = (data: Record<string, unknown>, columns?: string[]) => {
   const keys = columns ?? Object.keys(data)
-  if (keys.length === 0) return
+  if (keys.length === 0) {
+    return
+  }
 
   const maxKeyLen = Math.max(...keys.map((k) => k.length))
 
   for (const key of keys) {
-    if (!(key in data)) continue
+    if (!(key in data)) {
+      continue
+    }
     const label = key.padEnd(maxKeyLen)
     const value = formatValue(key, data[key])
     log(`${label}  ${value}`)

--- a/src/resources/__tests__/factory.test.ts
+++ b/src/resources/__tests__/factory.test.ts
@@ -43,7 +43,9 @@ vi.mock('@inquirer/prompts', () => ({
 // Mock async generator helper
 const asyncGenerator = (items: { serialize: () => Record<string, unknown> }[]) => {
   return (async function* () {
-    for (const item of items) yield item
+    for (const item of items) {
+      yield item
+    }
   })()
 }
 

--- a/src/resources/__tests__/factory.test.ts
+++ b/src/resources/__tests__/factory.test.ts
@@ -289,44 +289,14 @@ describe('factory: list command', () => {
     expect(printTable).not.toHaveBeenCalled()
   })
 
-  test('exits with error when --limit is not a valid number', async () => {
+  test.each(['abc', '0', '-5'])('exits with error when --limit is %s', async (value) => {
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
       throw new Error('process.exit')
     })
 
     const program = createProgram()
     await expect(
-      program.parseAsync(['payment_intents', 'list', '--limit', 'abc'], { from: 'user' }),
-    ).rejects.toThrow('process.exit')
-
-    expect(error).toHaveBeenCalledWith('--limit must be a positive number')
-    expect(mockManager.list).not.toHaveBeenCalled()
-    exitSpy.mockRestore()
-  })
-
-  test('exits with error when --limit is zero', async () => {
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('process.exit')
-    })
-
-    const program = createProgram()
-    await expect(
-      program.parseAsync(['payment_intents', 'list', '--limit', '0'], { from: 'user' }),
-    ).rejects.toThrow('process.exit')
-
-    expect(error).toHaveBeenCalledWith('--limit must be a positive number')
-    expect(mockManager.list).not.toHaveBeenCalled()
-    exitSpy.mockRestore()
-  })
-
-  test('exits with error when --limit is negative', async () => {
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('process.exit')
-    })
-
-    const program = createProgram()
-    await expect(
-      program.parseAsync(['payment_intents', 'list', '--limit', '-5'], { from: 'user' }),
+      program.parseAsync(['payment_intents', 'list', '--limit', value], { from: 'user' }),
     ).rejects.toThrow('process.exit')
 
     expect(error).toHaveBeenCalledWith('--limit must be a positive number')

--- a/src/resources/factory.ts
+++ b/src/resources/factory.ts
@@ -4,6 +4,7 @@ import type { FlagDef, ResourceDef, SdkManager, Serializable } from '../types.js
 import { confirm } from '@inquirer/prompts'
 import { createClient, resolveAuth } from '../lib/auth.js'
 import { readConfig } from '../lib/config.js'
+import { handleError } from '../lib/errors.js'
 import { error, log, printDetail, printJson, printTable, success } from '../lib/output.js'
 
 type RootOpts = {
@@ -86,8 +87,7 @@ const validateRequired = (cmd: Command, flags: FlagDef[], resourceName: string, 
 const resolveClient = (parentOpts: RootOpts, resource: ResourceDef) => {
   const auth = resolveAuth(parentOpts)
   const jwsPrivateKey = resource.needsJws ? readConfig().jws_private_key : undefined
-  const client = createClient(auth.secretKey, jwsPrivateKey)
-  return { client }
+  return createClient(auth.secretKey, jwsPrivateKey)
 }
 
 // Type predicate for SDK objects with a serialize() method
@@ -113,20 +113,24 @@ const registerCreate = (parent: Command, resource: ResourceDef) => {
     const rootOpts = getRootOpts(actionCmd)
     validateRequired(actionCmd, resource.createFlags ?? [], resource.cliCommand, 'create')
 
-    const body = collectSetOptions(actionCmd, resource.createFlags ?? [])
-    const { client } = resolveClient(rootOpts, resource)
-    const manager = getManager(client, resource)
+    try {
+      const body = collectSetOptions(actionCmd, resource.createFlags ?? [])
+      const client = resolveClient(rootOpts, resource)
+      const manager = getManager(client, resource)
 
-    if (!manager.create) throw new Error(`${resource.name} does not support create`)
-    const result = await manager.create(body)
-    const data = serialize(result)
+      if (!manager.create) throw new Error(`${resource.name} does not support create`)
+      const result = await manager.create(body)
+      const data = serialize(result)
 
-    if (rootOpts.json) {
-      printJson(data)
-    } else {
-      success(`${resource.displayName} created`)
-      log('')
-      printDetail(data, resource.priorityColumns)
+      if (rootOpts.json) {
+        printJson(data)
+      } else {
+        success(`${resource.displayName} created`)
+        log('')
+        printDetail(data, resource.priorityColumns)
+      }
+    } catch (err) {
+      handleError(err, { resourceName: resource.cliCommand, verb: 'create' })
     }
   })
 }
@@ -136,18 +140,22 @@ const registerGet = (parent: Command, resource: ResourceDef) => {
     .command('get <id>')
     .description(`Get a ${resource.displayName} by ID`)
     .action(async (id: string, _opts: unknown, actionCmd: Command) => {
-      const rootOpts = getRootOpts(actionCmd)
-      const { client } = resolveClient(rootOpts, resource)
-      const manager = getManager(client, resource)
+      try {
+        const rootOpts = getRootOpts(actionCmd)
+        const client = resolveClient(rootOpts, resource)
+        const manager = getManager(client, resource)
 
-      if (!manager.get) throw new Error(`${resource.name} does not support get`)
-      const result = await manager.get(id)
-      const data = serialize(result)
+        if (!manager.get) throw new Error(`${resource.name} does not support get`)
+        const result = await manager.get(id)
+        const data = serialize(result)
 
-      if (rootOpts.json) {
-        printJson(data)
-      } else {
-        printDetail(data, resource.priorityColumns)
+        if (rootOpts.json) {
+          printJson(data)
+        } else {
+          printDetail(data, resource.priorityColumns)
+        }
+      } catch (err) {
+        handleError(err, { resourceName: resource.cliCommand, verb: 'get', id })
       }
     })
 }
@@ -169,26 +177,30 @@ const registerList = (parent: Command, resource: ResourceDef) => {
       process.exit(1)
     }
 
-    const filters = collectSetOptions(actionCmd, resource.listFlags ?? [])
-    const { client } = resolveClient(rootOpts, resource)
-    const manager = getManager(client, resource)
+    try {
+      const filters = collectSetOptions(actionCmd, resource.listFlags ?? [])
+      const client = resolveClient(rootOpts, resource)
+      const manager = getManager(client, resource)
 
-    if (!manager.list) throw new Error(`${resource.name} does not support list`)
-    const generator = (await manager.list({ ...filters, lazy: true })) as AsyncIterable<unknown>
-    const items: Record<string, unknown>[] = []
+      if (!manager.list) throw new Error(`${resource.name} does not support list`)
+      const generator = (await manager.list({ ...filters, lazy: true })) as AsyncIterable<unknown>
+      const items: Record<string, unknown>[] = []
 
-    for await (const item of generator) {
-      items.push(serialize(item))
-      if (items.length >= limit) break
-    }
+      for await (const item of generator) {
+        items.push(serialize(item))
+        if (items.length >= limit) break
+      }
 
-    if (rootOpts.json) {
-      printJson(items)
-    } else {
-      printTable({
-        columns: resource.priorityColumns,
-        rows: items,
-      })
+      if (rootOpts.json) {
+        printJson(items)
+      } else {
+        printTable({
+          columns: resource.priorityColumns,
+          rows: items,
+        })
+      }
+    } catch (err) {
+      handleError(err, { resourceName: resource.cliCommand, verb: 'list' })
     }
   })
 }
@@ -216,12 +228,16 @@ const registerDelete = (parent: Command, resource: ResourceDef) => {
         }
       }
 
-      const { client } = resolveClient(rootOpts, resource)
-      const manager = getManager(client, resource)
+      try {
+        const client = resolveClient(rootOpts, resource)
+        const manager = getManager(client, resource)
 
-      if (!manager.delete) throw new Error(`${resource.name} does not support delete`)
-      await manager.delete(id)
-      success(`${resource.displayName} '${id}' deleted`)
+        if (!manager.delete) throw new Error(`${resource.name} does not support delete`)
+        await manager.delete(id)
+        success(`${resource.displayName} '${id}' deleted`)
+      } catch (err) {
+        handleError(err, { resourceName: resource.cliCommand, verb: 'delete', id })
+      }
     })
 }
 

--- a/src/resources/factory.ts
+++ b/src/resources/factory.ts
@@ -30,9 +30,15 @@ const getManager = (client: Fintoc, resource: ResourceDef) => {
 
 // Parse flag value according to its type
 const parseFlagValue = (value: string, flag: FlagDef) => {
-  if (flag.type === 'number') return Number(value)
-  if (flag.type === 'boolean') return value === 'true'
-  if (flag.type === 'string[]') return value.split(',').map((s) => s.trim())
+  if (flag.type === 'number') {
+    return Number(value)
+  }
+  if (flag.type === 'boolean') {
+    return value === 'true'
+  }
+  if (flag.type === 'string[]') {
+    return value.split(',').map((s) => s.trim())
+  }
   return value
 }
 
@@ -99,8 +105,12 @@ const isSerializable = (obj: unknown): obj is Serializable =>
 
 // Serialize SDK resource object to plain object
 const serialize = (obj: unknown): Record<string, unknown> => {
-  if (isSerializable(obj)) return obj.serialize()
-  if (typeof obj === 'object' && obj !== null) return { ...obj } as Record<string, unknown>
+  if (isSerializable(obj)) {
+    return obj.serialize()
+  }
+  if (typeof obj === 'object' && obj !== null) {
+    return { ...obj } as Record<string, unknown>
+  }
   return {}
 }
 
@@ -118,7 +128,9 @@ const registerCreate = (parent: Command, resource: ResourceDef) => {
       const client = resolveClient(rootOpts, resource)
       const manager = getManager(client, resource)
 
-      if (!manager.create) throw new Error(`${resource.name} does not support create`)
+      if (!manager.create) {
+        throw new Error(`${resource.name} does not support create`)
+      }
       const result = await manager.create(body)
       const data = serialize(result)
 
@@ -145,7 +157,9 @@ const registerGet = (parent: Command, resource: ResourceDef) => {
         const client = resolveClient(rootOpts, resource)
         const manager = getManager(client, resource)
 
-        if (!manager.get) throw new Error(`${resource.name} does not support get`)
+        if (!manager.get) {
+          throw new Error(`${resource.name} does not support get`)
+        }
         const result = await manager.get(id)
         const data = serialize(result)
 
@@ -182,13 +196,17 @@ const registerList = (parent: Command, resource: ResourceDef) => {
       const client = resolveClient(rootOpts, resource)
       const manager = getManager(client, resource)
 
-      if (!manager.list) throw new Error(`${resource.name} does not support list`)
+      if (!manager.list) {
+        throw new Error(`${resource.name} does not support list`)
+      }
       const generator = (await manager.list({ ...filters, lazy: true })) as AsyncIterable<unknown>
       const items: Record<string, unknown>[] = []
 
       for await (const item of generator) {
         items.push(serialize(item))
-        if (items.length >= limit) break
+        if (items.length >= limit) {
+          break
+        }
       }
 
       if (rootOpts.json) {
@@ -232,7 +250,9 @@ const registerDelete = (parent: Command, resource: ResourceDef) => {
         const client = resolveClient(rootOpts, resource)
         const manager = getManager(client, resource)
 
-        if (!manager.delete) throw new Error(`${resource.name} does not support delete`)
+        if (!manager.delete) {
+          throw new Error(`${resource.name} does not support delete`)
+        }
         await manager.delete(id)
         success(`${resource.displayName} '${id}' deleted`)
       } catch (err) {


### PR DESCRIPTION
## Contexto

Los errores del SDK se manejaban inline en cada comando. Se centraliza en un handler que muestra mensajes claros con next-steps accionables.

## Que hay de nuevo?

- [x] `lib/errors.ts` — handler que detecta: sin API key, conectividad, 404, auth inválida, JWS faltante
- [x] Factory y login command usan `handleError` en vez de formatear inline

## Tests

- [x] Tests unitarios para todos los escenarios de error

## Consideraciones

- Las clases de error del SDK no son exportadas, se detectan por `constructor.name`

[ONB-1784](https://linear.app/fintoc/issue/ONB-1784)

<sup>*Created with Claude Code `/create-pr` command*</sup>