### PR TITLE
[ONB-1817] Arreglar creación de pagos y agregar checkout_sessions

### DIFF
--- a/src/commands/__tests__/login.test.ts
+++ b/src/commands/__tests__/login.test.ts
@@ -31,6 +31,7 @@ vi.mock('@inquirer/prompts', () => ({
 const createProgram = () => {
   const program = new Command()
   program.exitOverride()
+  program.option('--api-key <key>', 'Override API key for this command')
   loginCommand(program)
   return program
 }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -11,12 +11,12 @@ export const loginCommand = (program: Command) => {
   program
     .command('login')
     .description('Authenticate with your Fintoc API key')
-    .option('--api-key <key>', 'API secret key (skips interactive prompt)')
-    .action(async (opts: { apiKey?: string }) => {
+    .action(async (_opts: unknown, actionCmd: Command) => {
       let secretKey: string
 
-      if (opts.apiKey) {
-        secretKey = opts.apiKey
+      const rootApiKey = actionCmd.parent?.opts().apiKey as string | undefined
+      if (rootApiKey) {
+        secretKey = rootApiKey
       } else if (process.stdin.isTTY) {
         secretKey = await password({ message: 'Enter your Fintoc secret key:' })
       } else {

--- a/src/resources/__tests__/factory.test.ts
+++ b/src/resources/__tests__/factory.test.ts
@@ -194,6 +194,68 @@ describe('factory: create command', () => {
     expect(printJson).toHaveBeenCalledWith({ id: 'pi_123', amount: 10000 })
     expect(printDetail).not.toHaveBeenCalled()
   })
+
+  test('assembles nested flags into nested objects via nestedPath', async () => {
+    const nestedResource: ResourceDef = {
+      name: 'checkout_sessions',
+      displayName: 'checkout session',
+      cliCommand: 'checkout_sessions',
+      sdkMethod: 'paymentIntents',
+      sdkNamespace: 'v1',
+      verbs: ['create'],
+      priorityColumns: ['id'],
+      createFlags: [
+        { name: 'amount', type: 'number', required: true },
+        { name: 'currency', type: 'string', required: true },
+        {
+          name: 'recipient-account-type',
+          type: 'string',
+          nestedPath: 'payment_method_options.payment_intent.recipient_account.type',
+        },
+        {
+          name: 'business-profile-tax-id',
+          type: 'string',
+          nestedPath: 'business_profile.tax_id',
+        },
+      ],
+      listFlags: [],
+    }
+
+    const mockResult = { serialize: () => ({ id: 'cs_123' }) }
+    mockManager.create.mockResolvedValue(mockResult)
+
+    const program = createProgram(nestedResource)
+    await program.parseAsync(
+      [
+        'checkout_sessions',
+        'create',
+        '--amount',
+        '5000',
+        '--currency',
+        'CLP',
+        '--recipient-account-type',
+        'checking_account',
+        '--business-profile-tax-id',
+        '11111111-1',
+      ],
+      { from: 'user' },
+    )
+
+    expect(mockManager.create).toHaveBeenCalledWith({
+      amount: 5000,
+      currency: 'CLP',
+      payment_method_options: {
+        payment_intent: {
+          recipient_account: {
+            type: 'checking_account',
+          },
+        },
+      },
+      business_profile: {
+        tax_id: '11111111-1',
+      },
+    })
+  })
 })
 
 describe('factory: get command', () => {

--- a/src/resources/__tests__/registry.test.ts
+++ b/src/resources/__tests__/registry.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, test } from 'vitest'
 import { resources } from '../registry.js'
 
 describe('resource registry', () => {
-  test('contains all 8 resources', () => {
-    expect(resources).toHaveLength(8)
+  test('contains all 9 resources', () => {
+    expect(resources).toHaveLength(9)
 
     const names = resources.map((r) => r.name)
     expect(names).toEqual([
@@ -15,6 +15,7 @@ describe('resource registry', () => {
       'charges',
       'subscriptions',
       'links',
+      'checkout_sessions',
       'api_keys',
     ])
   })
@@ -32,7 +33,7 @@ describe('resource registry', () => {
   })
 
   test('verbs are valid', () => {
-    const validVerbs = new Set(['create', 'get', 'list', 'delete'])
+    const validVerbs = new Set(['create', 'get', 'list', 'delete', 'expire'])
     resources.forEach((resource) => {
       resource.verbs.forEach((verb) => {
         expect(validVerbs.has(verb)).toBe(true)
@@ -50,8 +51,8 @@ describe('resource registry', () => {
   })
 
   test('createFlags with required=true exist for resources that need them', () => {
-    const paymentIntents = resources.find((r) => r.name === 'payment_intents')!
-    const requiredFlags = paymentIntents.createFlags!.filter((f) => f.required)
+    const checkoutSessions = resources.find((r) => r.name === 'checkout_sessions')!
+    const requiredFlags = checkoutSessions.createFlags!.filter((f) => f.required)
     expect(requiredFlags.map((f) => f.name)).toEqual(['amount', 'currency'])
   })
 

--- a/src/resources/factory.ts
+++ b/src/resources/factory.ts
@@ -52,6 +52,20 @@ const addFlags = (cmd: Command, flags: FlagDef[]) => {
   }
 }
 
+// Set a value at a dot-separated path in a nested object
+const setNestedValue = (obj: Record<string, unknown>, path: string, value: unknown) => {
+  const keys = path.split('.')
+  let current = obj
+  for (let i = 0; i < keys.length - 1; i++) {
+    const key = keys[i]
+    if (!(key in current) || typeof current[key] !== 'object' || current[key] === null) {
+      current[key] = {}
+    }
+    current = current[key] as Record<string, unknown>
+  }
+  current[keys[keys.length - 1]] = value
+}
+
 // Collect only explicitly-set option values (skip Commander defaults)
 const collectSetOptions = (cmd: Command, flags: FlagDef[]) => {
   const opts = cmd.opts()
@@ -60,8 +74,13 @@ const collectSetOptions = (cmd: Command, flags: FlagDef[]) => {
   for (const flag of flags) {
     const camelName = toCamelCase(flag.name)
     if (opts[camelName] !== undefined) {
-      const snakeName = toSnakeCase(flag.name)
-      result[snakeName] = parseFlagValue(String(opts[camelName]), flag)
+      const value = parseFlagValue(String(opts[camelName]), flag)
+      if (flag.nestedPath) {
+        setNestedValue(result, flag.nestedPath, value)
+      } else {
+        const snakeName = toSnakeCase(flag.name)
+        result[snakeName] = value
+      }
     }
   }
 
@@ -115,7 +134,9 @@ const serialize = (obj: unknown): Record<string, unknown> => {
 }
 
 const registerCreate = (parent: Command, resource: ResourceDef) => {
-  const cmd = parent.command('create').description(`Create a new ${resource.displayName}`)
+  const cmd = parent
+    .command('create')
+    .description(`Create a new ${resource.displayName}`)
 
   addFlags(cmd, resource.createFlags ?? [])
 
@@ -128,10 +149,7 @@ const registerCreate = (parent: Command, resource: ResourceDef) => {
       const client = resolveClient(rootOpts, resource)
       const manager = getManager(client, resource)
 
-      if (!manager.create) {
-        throw new Error(`${resource.name} does not support create`)
-      }
-      const result = await manager.create(body)
+      const result = await manager.create!(body)
       const data = serialize(result)
 
       if (rootOpts.json) {
@@ -157,10 +175,7 @@ const registerGet = (parent: Command, resource: ResourceDef) => {
         const client = resolveClient(rootOpts, resource)
         const manager = getManager(client, resource)
 
-        if (!manager.get) {
-          throw new Error(`${resource.name} does not support get`)
-        }
-        const result = await manager.get(id)
+        const result = await manager.get!(id)
         const data = serialize(result)
 
         if (rootOpts.json) {
@@ -196,10 +211,7 @@ const registerList = (parent: Command, resource: ResourceDef) => {
       const client = resolveClient(rootOpts, resource)
       const manager = getManager(client, resource)
 
-      if (!manager.list) {
-        throw new Error(`${resource.name} does not support list`)
-      }
-      const generator = (await manager.list({ ...filters, lazy: true })) as AsyncIterable<unknown>
+      const generator = (await manager.list!({ ...filters, lazy: true })) as AsyncIterable<unknown>
       const items: Record<string, unknown>[] = []
 
       for await (const item of generator) {
@@ -250,13 +262,45 @@ const registerDelete = (parent: Command, resource: ResourceDef) => {
         const client = resolveClient(rootOpts, resource)
         const manager = getManager(client, resource)
 
-        if (!manager.delete) {
-          throw new Error(`${resource.name} does not support delete`)
-        }
-        await manager.delete(id)
+        await manager.delete!(id)
         success(`${resource.displayName} '${id}' deleted`)
       } catch (err) {
         handleError(err, { resourceName: resource.cliCommand, verb: 'delete', id })
+      }
+    })
+}
+
+const registerExpire = (parent: Command, resource: ResourceDef) => {
+  parent
+    .command('expire <id>')
+    .description(`Expire a ${resource.displayName}`)
+    .option('--yes', 'Skip confirmation prompt')
+    .action(async (id: string, opts: { yes?: boolean }, actionCmd: Command) => {
+      const rootOpts = getRootOpts(actionCmd)
+
+      if (!opts.yes) {
+        if (!process.stdin.isTTY) {
+          error(`Confirmation required to expire '${id}'. Use --yes to skip.`)
+          process.exit(1)
+        }
+        const confirmed = await confirm({
+          message: `Are you sure you want to expire '${id}'?`,
+          default: false,
+        })
+        if (!confirmed) {
+          log('Aborted.')
+          return
+        }
+      }
+
+      try {
+        const client = resolveClient(rootOpts, resource)
+        const manager = getManager(client, resource)
+
+        await manager.expire!(id)
+        success(`${resource.displayName} '${id}' expired`)
+      } catch (err) {
+        handleError(err, { resourceName: resource.cliCommand, verb: 'expire', id })
       }
     })
 }
@@ -266,6 +310,7 @@ const verbRegistrars = {
   get: registerGet,
   list: registerList,
   delete: registerDelete,
+  expire: registerExpire,
 } satisfies Record<string, (parent: Command, resource: ResourceDef) => void>
 
 export const registerResourceCommands = (program: Command, resourceDefs: ResourceDef[]) => {

--- a/src/resources/factory.ts
+++ b/src/resources/factory.ts
@@ -134,9 +134,7 @@ const serialize = (obj: unknown): Record<string, unknown> => {
 }
 
 const registerCreate = (parent: Command, resource: ResourceDef) => {
-  const cmd = parent
-    .command('create')
-    .description(`Create a new ${resource.displayName}`)
+  const cmd = parent.command('create').description(`Create a new ${resource.displayName}`)
 
   addFlags(cmd, resource.createFlags ?? [])
 

--- a/src/resources/registry.ts
+++ b/src/resources/registry.ts
@@ -7,27 +7,8 @@ export const resources: ResourceDef[] = [
     cliCommand: 'payment_intents',
     sdkMethod: 'paymentIntents',
     sdkNamespace: 'v1',
-    verbs: ['create', 'get', 'list'],
+    verbs: ['get', 'list'],
     priorityColumns: ['id', 'amount', 'currency', 'status', 'created_at'],
-    createFlags: [
-      {
-        name: 'amount',
-        type: 'number',
-        required: true,
-        description: 'Amount in smallest currency unit',
-      },
-      {
-        name: 'currency',
-        type: 'string',
-        required: true,
-        description: 'Currency code (e.g., CLP, MXN)',
-      },
-      {
-        name: 'customer-email',
-        type: 'string',
-        description: 'Customer email address',
-      },
-    ],
     listFlags: [
       {
         name: 'status',
@@ -54,7 +35,7 @@ export const resources: ResourceDef[] = [
     sdkNamespace: 'v2',
     verbs: ['create', 'get', 'list'],
     needsJws: true,
-    priorityColumns: ['id', 'amount', 'currency', 'status', 'created_at'],
+    priorityColumns: ['id', 'amount', 'currency', 'status', 'transaction_date'],
     createFlags: [
       {
         name: 'amount',
@@ -147,7 +128,13 @@ export const resources: ResourceDef[] = [
         name: 'currency',
         type: 'string',
         required: true,
-        description: 'Currency code (e.g., CLP, MXN)',
+        description: 'Currency code (e.g., CLP)',
+      },
+      {
+        name: 'subscription-id',
+        type: 'string',
+        required: true,
+        description: 'Subscription ID to charge',
       },
     ],
     listFlags: [
@@ -211,13 +198,94 @@ export const resources: ResourceDef[] = [
     ],
   },
   {
+    name: 'checkout_sessions',
+    displayName: 'checkout session',
+    cliCommand: 'checkout_sessions',
+    sdkMethod: 'checkoutSessions',
+    sdkNamespace: 'v1',
+    verbs: ['create', 'get', 'expire'],
+    priorityColumns: ['id', 'amount', 'currency', 'status', 'created_at'],
+    createFlags: [
+      {
+        name: 'amount',
+        type: 'number',
+        required: true,
+        description: 'Amount to pay in smallest currency unit (must be > 0 and < 7000000)',
+      },
+      {
+        name: 'currency',
+        type: 'string',
+        required: true,
+        description: 'Currency code (CLP, MXN)',
+      },
+      {
+        name: 'success-url',
+        type: 'string',
+        description: 'Redirect URL after successful payment',
+      },
+      {
+        name: 'cancel-url',
+        type: 'string',
+        description: 'Redirect URL if customer cancels',
+      },
+      {
+        name: 'customer-email',
+        type: 'string',
+        description: 'Customer email for refund notifications',
+      },
+      {
+        name: 'recipient-account-type',
+        type: 'string',
+        description: 'Recipient account type (checking_account, sight_account)',
+        nestedPath: 'payment_method_options.payment_intent.recipient_account.type',
+      },
+      {
+        name: 'recipient-account-number',
+        type: 'string',
+        description: 'Recipient account number',
+        nestedPath: 'payment_method_options.payment_intent.recipient_account.number',
+      },
+      {
+        name: 'recipient-account-holder-id',
+        type: 'string',
+        description: 'Recipient account holder ID (e.g., RUT in Chile)',
+        nestedPath: 'payment_method_options.payment_intent.recipient_account.holder_id',
+      },
+      {
+        name: 'recipient-account-institution-id',
+        type: 'string',
+        description: 'Recipient bank institution ID (e.g., cl_banco_estado)',
+        nestedPath: 'payment_method_options.payment_intent.recipient_account.institution_id',
+      },
+      {
+        name: 'business-profile-tax-id',
+        type: 'string',
+        description: 'Merchant tax ID (e.g., RUT in Chile)',
+        nestedPath: 'business_profile.tax_id',
+      },
+      {
+        name: 'business-profile-name',
+        type: 'string',
+        description: 'Merchant display name',
+        nestedPath: 'business_profile.name',
+      },
+      {
+        name: 'business-profile-category',
+        type: 'string',
+        description: 'Merchant activity code (6 characters in Chile)',
+        nestedPath: 'business_profile.category',
+      },
+    ],
+    listFlags: [],
+  },
+  {
     name: 'api_keys',
     displayName: 'API key',
     cliCommand: 'api_keys',
     sdkMethod: 'apiKeys',
     sdkNamespace: 'v1',
     verbs: ['list'],
-    priorityColumns: ['id', 'name', 'mode', 'last_four', 'created_at'],
+    priorityColumns: ['token', 'mode', 'is_public', 'created_at'],
     listFlags: [],
   },
 ]

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ export type FintocConfig = {
   jws_private_key?: string
 }
 
-export type Verb = 'create' | 'get' | 'list' | 'delete'
+export type Verb = 'create' | 'get' | 'list' | 'delete' | 'expire'
 
 export type FlagType = 'string' | 'number' | 'boolean' | 'string[]'
 
@@ -12,6 +12,7 @@ export type FlagDef = {
   type: FlagType
   required?: boolean
   description?: string
+  nestedPath?: string
 }
 
 export type ResourceDef = {
@@ -32,6 +33,7 @@ export type SdkManager = {
   get?: (id: string) => Promise<unknown>
   list?: (params: Record<string, unknown>) => Promise<unknown>
   delete?: (id: string) => Promise<unknown>
+  expire?: (id: string) => Promise<unknown>
 }
 
 export type Serializable = {


### PR DESCRIPTION
## Contexto

QA reveló problemas en el registry y el flujo de creación de pagos. La API usa `checkout_sessions` en vez de `payment_intents create`.

## Que hay de nuevo?

- [x] Fix `login --api-key` (conflicto flag local vs global)
- [x] Soporte `nestedPath` en flags + nuevo verbo `expire`
- [x] Nuevo recurso `checkout_sessions` (create, get, expire)
- [x] Fixes en registry: columnas, flags faltantes, remoción de `payment_intents create`

## Tests

- [x] Tests unitarios para nestedPath y registry

<sup>*Created with Claude Code `/create-pr` command*</sup>