### PR TITLE
[ONB-1818] M6: DX Utilities — doctor, open dashboard, help grouping

### DIFF
--- a/src/commands/__tests__/doctor.test.ts
+++ b/src/commands/__tests__/doctor.test.ts
@@ -1,0 +1,149 @@
+import { Command } from 'commander'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { resolveAuth, whoami } from '../../lib/auth.js'
+import { readConfig } from '../../lib/config.js'
+import { error, log, success, warn } from '../../lib/output.js'
+import { doctorCommand } from '../doctor.js'
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+}))
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  statSync: vi.fn(),
+}))
+
+vi.mock('../../lib/auth.js', () => ({
+  resolveAuth: vi.fn(),
+  whoami: vi.fn(),
+  maskKey: vi.fn((k: string) => `${k.slice(0, 8)}····`),
+}))
+
+vi.mock('../../lib/config.js', () => ({
+  CONFIG_PATH: '/mock-home/.fintoc/config.toml',
+  readConfig: vi.fn(),
+}))
+
+vi.mock('../../lib/output.js', () => ({
+  log: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+}))
+
+vi.mock('../../lib/version.js', () => ({
+  getCliVersion: vi.fn(() => '0.1.0'),
+}))
+
+const createProgram = () => {
+  const program = new Command()
+  program.exitOverride()
+  doctorCommand(program)
+  return program
+}
+
+describe('doctor command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(readConfig).mockReturnValue({})
+  })
+
+  test('all checks pass', async () => {
+    const { execSync } = await import('node:child_process')
+    const { existsSync, statSync } = await import('node:fs')
+
+    vi.mocked(execSync).mockReturnValue('0.1.0\n')
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(statSync).mockReturnValue({ mode: 0o100600 } as ReturnType<typeof statSync>)
+    vi.mocked(resolveAuth).mockReturnValue({ secretKey: 'sk_test_abc123', source: 'config' })
+    vi.mocked(whoami).mockResolvedValue({
+      organizationName: 'Acme Corp',
+      mode: 'test',
+      apiVersion: '2023-03-15',
+    })
+
+    const program = createProgram()
+    await program.parseAsync(['doctor'], { from: 'user' })
+
+    expect(success).toHaveBeenCalledWith(expect.stringContaining('CLI version'))
+    expect(success).toHaveBeenCalledWith(expect.stringContaining('Config file'))
+    expect(success).toHaveBeenCalledWith(expect.stringContaining('API key'))
+    expect(success).toHaveBeenCalledWith(expect.stringContaining('Connectivity'))
+    expect(success).toHaveBeenCalledWith(expect.stringContaining('Acme Corp'))
+    // JWS key is not configured in this test, so one error is expected
+    expect(error).toHaveBeenCalledTimes(1)
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('JWS private key'))
+  })
+
+  test('no API key configured — skips connectivity', async () => {
+    const { execSync } = await import('node:child_process')
+    const { existsSync, statSync } = await import('node:fs')
+
+    vi.mocked(execSync).mockReturnValue('0.1.0\n')
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(statSync).mockReturnValue({ mode: 0o100600 } as ReturnType<typeof statSync>)
+    vi.mocked(resolveAuth).mockImplementation(() => {
+      throw new Error('No API key')
+    })
+
+    const program = createProgram()
+    await program.parseAsync(['doctor'], { from: 'user' })
+
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('API key'))
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('skipped'))
+    expect(whoami).not.toHaveBeenCalled()
+  })
+
+  test('API unreachable', async () => {
+    const { execSync } = await import('node:child_process')
+    const { existsSync, statSync } = await import('node:fs')
+
+    vi.mocked(execSync).mockReturnValue('0.1.0\n')
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(statSync).mockReturnValue({ mode: 0o100600 } as ReturnType<typeof statSync>)
+    vi.mocked(resolveAuth).mockReturnValue({ secretKey: 'sk_test_abc123', source: 'config' })
+    vi.mocked(whoami).mockRejectedValue(new Error('Network error'))
+
+    const program = createProgram()
+    await program.parseAsync(['doctor'], { from: 'user' })
+
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('could not reach'))
+  })
+
+  test('outdated CLI version', async () => {
+    const { execSync } = await import('node:child_process')
+    const { existsSync, statSync } = await import('node:fs')
+
+    vi.mocked(execSync).mockReturnValue('0.2.0\n')
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(statSync).mockReturnValue({ mode: 0o100600 } as ReturnType<typeof statSync>)
+    vi.mocked(resolveAuth).mockReturnValue({ secretKey: 'sk_test_abc123', source: 'config' })
+    vi.mocked(whoami).mockResolvedValue({
+      organizationName: 'Acme Corp',
+      mode: 'test',
+      apiVersion: '2023-03-15',
+    })
+
+    const program = createProgram()
+    await program.parseAsync(['doctor'], { from: 'user' })
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('latest: 0.2.0'))
+  })
+
+  test('config file missing', async () => {
+    const { execSync } = await import('node:child_process')
+    const { existsSync } = await import('node:fs')
+
+    vi.mocked(execSync).mockReturnValue('0.1.0\n')
+    vi.mocked(existsSync).mockReturnValue(false)
+    vi.mocked(resolveAuth).mockImplementation(() => {
+      throw new Error('No API key')
+    })
+
+    const program = createProgram()
+    await program.parseAsync(['doctor'], { from: 'user' })
+
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('not found'))
+  })
+})

--- a/src/commands/__tests__/open.test.ts
+++ b/src/commands/__tests__/open.test.ts
@@ -1,0 +1,126 @@
+import { Command } from 'commander'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { error, success } from '../../lib/output.js'
+import { openCommand } from '../open.js'
+
+vi.mock('node:child_process', () => ({
+  exec: vi.fn(),
+}))
+
+vi.mock('../../lib/output.js', () => ({
+  success: vi.fn(),
+  error: vi.fn(),
+}))
+
+const createProgram = () => {
+  const program = new Command()
+  program.exitOverride()
+  openCommand(program)
+  return program
+}
+
+describe('open command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('open dashboard', () => {
+    test('opens dashboard URL in browser on macOS', async () => {
+      const { exec } = await import('node:child_process')
+      const originalPlatform = process.platform
+      Object.defineProperty(process, 'platform', { value: 'darwin' })
+
+      vi.mocked(exec).mockImplementation((_cmd, callback) => {
+        ;(callback as (err: Error | null) => void)(null)
+        return undefined as never
+      })
+
+      const program = createProgram()
+      await program.parseAsync(['open', 'dashboard'], { from: 'user' })
+
+      expect(exec).toHaveBeenCalledWith(
+        'open "https://dashboard.fintoc.com/"',
+        expect.any(Function),
+      )
+      expect(success).toHaveBeenCalledWith(expect.stringContaining('https://dashboard.fintoc.com/'))
+
+      Object.defineProperty(process, 'platform', { value: originalPlatform })
+    })
+
+    test('uses xdg-open on Linux', async () => {
+      const { exec } = await import('node:child_process')
+      const originalPlatform = process.platform
+      Object.defineProperty(process, 'platform', { value: 'linux' })
+
+      vi.mocked(exec).mockImplementation((_cmd, callback) => {
+        ;(callback as (err: Error | null) => void)(null)
+        return undefined as never
+      })
+
+      const program = createProgram()
+      await program.parseAsync(['open', 'dashboard'], { from: 'user' })
+
+      expect(exec).toHaveBeenCalledWith(
+        'xdg-open "https://dashboard.fintoc.com/"',
+        expect.any(Function),
+      )
+
+      Object.defineProperty(process, 'platform', { value: originalPlatform })
+    })
+
+    test('uses start on Windows', async () => {
+      const { exec } = await import('node:child_process')
+      const originalPlatform = process.platform
+      Object.defineProperty(process, 'platform', { value: 'win32' })
+
+      vi.mocked(exec).mockImplementation((_cmd, callback) => {
+        ;(callback as (err: Error | null) => void)(null)
+        return undefined as never
+      })
+
+      const program = createProgram()
+      await program.parseAsync(['open', 'dashboard'], { from: 'user' })
+
+      expect(exec).toHaveBeenCalledWith(
+        'start "" "https://dashboard.fintoc.com/"',
+        expect.any(Function),
+      )
+
+      Object.defineProperty(process, 'platform', { value: originalPlatform })
+    })
+
+    test('logs error when browser fails to open', async () => {
+      const { exec } = await import('node:child_process')
+      const originalPlatform = process.platform
+      Object.defineProperty(process, 'platform', { value: 'darwin' })
+
+      vi.mocked(exec).mockImplementation((_cmd, callback) => {
+        ;(callback as (err: Error | null) => void)(new Error('spawn open ENOENT'))
+        return undefined as never
+      })
+
+      const program = createProgram()
+      await program.parseAsync(['open', 'dashboard'], { from: 'user' })
+
+      expect(error).toHaveBeenCalledWith(expect.stringContaining('Failed to open browser'))
+      expect(success).not.toHaveBeenCalled()
+
+      Object.defineProperty(process, 'platform', { value: originalPlatform })
+    })
+
+    test('shows friendly error on unsupported platform', async () => {
+      const { exec } = await import('node:child_process')
+      const originalPlatform = process.platform
+      Object.defineProperty(process, 'platform', { value: 'freebsd' })
+
+      const program = createProgram()
+      await program.parseAsync(['open', 'dashboard'], { from: 'user' })
+
+      expect(exec).not.toHaveBeenCalled()
+      expect(error).toHaveBeenCalledWith(expect.stringContaining('Unsupported platform'))
+      expect(success).not.toHaveBeenCalled()
+
+      Object.defineProperty(process, 'platform', { value: originalPlatform })
+    })
+  })
+})

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -8,7 +8,7 @@ export const configCommand = (program: Command) => {
   program
     .command('config')
     .description('Show current configuration')
-    .action(async () => {
+    .action(async (_opts: unknown, cmd: Command) => {
       let secretKey: string
       let source: string
 
@@ -18,8 +18,10 @@ export const configCommand = (program: Command) => {
         config: 'config file',
       } satisfies Record<string, string>
 
+      const rootOpts = cmd.parent!.opts<{ apiKey?: string }>()
+
       try {
-        const auth = resolveAuth()
+        const auth = resolveAuth(rootOpts)
         secretKey = auth.secretKey
         source = sourceLabels[auth.source]
       } catch {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,0 +1,106 @@
+import type { Command } from 'commander'
+import { execSync } from 'node:child_process'
+import { existsSync, statSync } from 'node:fs'
+
+import { maskKey, resolveAuth, whoami } from '../lib/auth.js'
+import { CONFIG_PATH, readConfig } from '../lib/config.js'
+import { error, log, success, warn } from '../lib/output.js'
+import { getCliVersion } from '../lib/version.js'
+
+const checkCliVersion = () => {
+  const currentVersion = getCliVersion()
+  try {
+    const latest = execSync('npm view @fintoc/cli version', {
+      encoding: 'utf-8',
+      timeout: 10_000,
+    }).trim()
+
+    if (latest === currentVersion) {
+      success(`CLI version         ${currentVersion} (latest)`)
+    } else {
+      warn(`CLI version         ${currentVersion} (latest: ${latest})`)
+    }
+  } catch {
+    success(`CLI version         ${currentVersion}`)
+    log('                    (could not check for updates)')
+  }
+}
+
+const checkConfigFile = () => {
+  if (!existsSync(CONFIG_PATH)) {
+    error(`Config file         ${CONFIG_PATH} not found`)
+    return
+  }
+
+  const stats = statSync(CONFIG_PATH)
+  const mode = stats.mode & 0o777
+  if (mode !== 0o600) {
+    warn(
+      `Config file         ${CONFIG_PATH} found (permissions: ${mode.toString(8)}, expected: 600)`,
+    )
+    return
+  }
+
+  success(`Config file         ${CONFIG_PATH} found`)
+}
+
+const checkApiKey = (options?: { apiKey?: string }) => {
+  try {
+    const auth = resolveAuth(options)
+    success(`API key             ${maskKey(auth.secretKey)} (source: ${auth.source})`)
+    return auth.secretKey
+  } catch {
+    error('API key             not configured')
+    log('                    Run `fintoc login` or set FINTOC_SECRET_KEY')
+    return null
+  }
+}
+
+const checkConnectivity = async (secretKey: string) => {
+  try {
+    const info = await whoami(secretKey)
+    success(`Connectivity        api.fintoc.com reachable`)
+    success(`Organization        ${info.organizationName} (${info.mode} mode)`)
+  } catch {
+    error('Connectivity        could not reach api.fintoc.com')
+    log('                    Check your internet connection and API key')
+  }
+}
+
+const checkJwsKey = () => {
+  const config = readConfig()
+  if (!config.jws_private_key) {
+    error('JWS private key     not configured (required for transfers create)')
+    return
+  }
+
+  if (!existsSync(config.jws_private_key)) {
+    error(`JWS private key     file not found: ${config.jws_private_key}`)
+    return
+  }
+
+  success(`JWS private key     ${config.jws_private_key}`)
+}
+
+export const doctorCommand = (program: Command) => {
+  program
+    .command('doctor')
+    .description('Check CLI setup and connectivity')
+    .action(async (_opts: unknown, cmd: Command) => {
+      const rootOpts = cmd.parent!.opts<{ apiKey?: string }>()
+      log('')
+      checkCliVersion()
+      checkConfigFile()
+      const secretKey = checkApiKey(rootOpts)
+
+      if (secretKey) {
+        await checkConnectivity(secretKey)
+      } else {
+        log('  ⏭ Connectivity     skipped (no API key)')
+        log('  ⏭ Organization     skipped (no API key)')
+      }
+
+      checkJwsKey()
+      log('')
+    })
+}

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -1,0 +1,43 @@
+import type { Command } from 'commander'
+import { exec } from 'node:child_process'
+
+import { error, success } from '../lib/output.js'
+
+const DASHBOARD_URL = 'https://dashboard.fintoc.com/'
+
+const openInBrowser = (url: string): Promise<void> => {
+  const commands: Record<string, string> = {
+    darwin: `open "${url}"`,
+    linux: `xdg-open "${url}"`,
+    win32: `start "" "${url}"`,
+  }
+
+  const cmd = commands[process.platform]
+  if (!cmd) {
+    error(`Unsupported platform: ${process.platform}`)
+    process.exitCode = 1
+    return Promise.resolve()
+  }
+
+  return new Promise((resolve) => {
+    exec(cmd, (err) => {
+      if (err) {
+        error(`Failed to open browser: ${err.message}`)
+      } else {
+        success(`Opening ${url} in your browser...`)
+      }
+      resolve()
+    })
+  })
+}
+
+export const openCommand = (program: Command) => {
+  const open = program.command('open').description('Open Fintoc resources in the browser')
+
+  open
+    .command('dashboard')
+    .description('Open the Fintoc dashboard')
+    .action(async () => {
+      await openInBrowser(DASHBOARD_URL)
+    })
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,20 @@
+import type { Help } from 'commander'
 import { Command } from 'commander'
 
 import { configCommand } from './commands/config.js'
+import { doctorCommand } from './commands/doctor.js'
 import { loginCommand } from './commands/login.js'
 import { logoutCommand } from './commands/logout.js'
+import { openCommand } from './commands/open.js'
 import { registerResourceCommands } from './resources/factory.js'
 import { resources } from './resources/registry.js'
 
 declare const __CLI_VERSION__: string
 
 const versionString = `fintoc/${__CLI_VERSION__} ${process.platform} node-${process.version}`
+
+const AUTH_COMMANDS = new Set(['login', 'logout', 'config'])
+const UTILITY_COMMANDS = new Set(['doctor', 'open'])
 
 const program = new Command()
 
@@ -22,6 +28,56 @@ program
 loginCommand(program)
 logoutCommand(program)
 configCommand(program)
+doctorCommand(program)
+openCommand(program)
 registerResourceCommands(program, resources)
+
+program.configureHelp({
+  formatHelp: (cmd: Command, helper: Help) => {
+    const lines: string[] = []
+
+    lines.push(cmd.description())
+    lines.push('')
+    lines.push(`Usage: ${cmd.name()} <command> [flags]`)
+
+    const subcommands = cmd.commands
+    const padWidth = Math.max(...subcommands.map((c) => c.name().length), 0) + 2
+
+    const formatGroup = (title: string, cmds: Command[]) => {
+      if (cmds.length === 0) {
+        return
+      }
+      lines.push('')
+      lines.push(`${title}:`)
+      for (const c of cmds) {
+        lines.push(`  ${c.name().padEnd(padWidth)}${c.description()}`)
+      }
+    }
+
+    const authCmds = subcommands.filter((c) => AUTH_COMMANDS.has(c.name()))
+    const utilityCmds = subcommands.filter((c) => UTILITY_COMMANDS.has(c.name()))
+    const resourceCmds = subcommands.filter(
+      (c) => !AUTH_COMMANDS.has(c.name()) && !UTILITY_COMMANDS.has(c.name()),
+    )
+
+    formatGroup('Auth', authCmds)
+    formatGroup('Resources', resourceCmds)
+    formatGroup('Utilities', utilityCmds)
+
+    lines.push('')
+    lines.push('Flags:')
+    const options = helper.visibleOptions(cmd)
+    const optPadWidth = Math.max(...options.map((o) => helper.optionTerm(o).length), 0) + 2
+    for (const opt of options) {
+      lines.push(`  ${helper.optionTerm(opt).padEnd(optPadWidth)}${opt.description}`)
+    }
+
+    lines.push('')
+    lines.push('Get started: fintoc login')
+    lines.push('')
+
+    return lines.join('\n')
+  },
+})
 
 program.parse()

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,0 +1,3 @@
+declare const __CLI_VERSION__: string
+
+export const getCliVersion = () => __CLI_VERSION__


### PR DESCRIPTION
## Contexto

Milestone M6 del CLI: comandos de diagnóstico y DX.

## Que hay de nuevo?

- [x] `fintoc doctor` — checks de CLI version, config, API key, connectivity, JWS
- [x] `fintoc open dashboard` — abre el dashboard en el browser
- [x] Help agrupado por categoría (Auth, Resources, Utilities)
- [x] Fix: `config` y `doctor` respetan `--api-key`

## Tests

- [x] Tests unitarios para `doctor` y `open`

<sup>*Created with Claude Code `/create-pr` command*</sup>