### PR TITLE
[ONB-1819] Soporte --from-json en create commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,14 @@ Requires Node.js >= 22.
 # Authenticate with your API key
 fintoc login
 
-# Check your current configuration
-fintoc config
+# List payment intents
+fintoc payment_intents list
 
-# Remove stored credentials
-fintoc logout
+# Create a charge from a JSON file
+fintoc charges create --from-json payload.json
+
+# Check your setup
+fintoc doctor
 ```
 
 ## Authentication
@@ -31,32 +34,79 @@ The CLI resolves your API key in this order:
 2. `FINTOC_SECRET_KEY` environment variable
 3. `~/.fintoc/config.toml` (saved via `fintoc login`)
 
-### `fintoc login`
+```bash
+# Interactive login
+fintoc login
 
-Interactive prompt to save your API key. Validates the key against the Fintoc API before storing it.
+# Non-interactive
+fintoc login --api-key sk_test_...
+
+# One-off override
+fintoc payment_intents list --api-key sk_test_...
+
+# Show active configuration
+fintoc config
+
+# Remove stored credentials
+fintoc logout
+```
+
+## Resources
+
+| Resource | create | get | list | delete | expire |
+|----------|:------:|:---:|:----:|:------:|:------:|
+| `payment_intents` | | ✔ | ✔ | | |
+| `transfers` | ✔ | ✔ | ✔ | | |
+| `accounts` | | ✔ | ✔ | | |
+| `webhook_endpoints` | ✔ | ✔ | ✔ | ✔ | |
+| `charges` | ✔ | ✔ | ✔ | | |
+| `subscriptions` | | ✔ | ✔ | | |
+| `links` | | ✔ | ✔ | ✔ | |
+| `checkout_sessions` | ✔ | ✔ | | | ✔ |
+| `api_keys` | | | ✔ | | |
+
+### Examples
 
 ```bash
-fintoc login
-# Or non-interactively:
-fintoc login --api-key sk_test_...
+# Get a resource by ID
+fintoc payment_intents get pi_test_abc123
+
+# List with filters
+fintoc charges list --status succeeded --since 2026-01-01
+
+# Create with flags
+fintoc transfers create --amount 10000 --currency CLP --counterparty-account-number 12345678
+
+# Create from a JSON file
+fintoc checkout_sessions create --from-json session.json
+
+# Pipe from stdin
+cat payload.json | fintoc charges create --from-json -
+
+# Mix JSON body with flag overrides
+fintoc charges create --from-json base.json --amount 5000
+
+# Delete with confirmation skip
+fintoc webhook_endpoints delete we_test_abc123 --yes
 ```
 
-### `fintoc logout`
+### Output
 
-Removes stored credentials from `~/.fintoc/config.toml`.
+By default the CLI prints a formatted table. Use `--json` for machine-readable output:
 
-### `fintoc config`
-
-Displays the active configuration: organization, mode (test/live), masked API key, and credential source.
-
+```bash
+fintoc payment_intents list --json
+fintoc charges get ch_test_abc123 --json
 ```
-$ fintoc config
-  Organization:  Acme Corp
-  Mode:          test
-  Secret key:    sk_test_····
-  API version:   2023-11-15
-  Config path:   ~/.fintoc/config.toml
-  Source:        config file
+
+## Utilities
+
+```bash
+# Diagnose setup and connectivity
+fintoc doctor
+
+# Open the Fintoc dashboard in your browser
+fintoc open dashboard
 ```
 
 ## Development

--- a/src/resources/__tests__/factory.test.ts
+++ b/src/resources/__tests__/factory.test.ts
@@ -17,6 +17,11 @@ const { mockManager, mockClient } = vi.hoisted(() => {
   return { mockManager, mockClient }
 })
 
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  return { ...actual, readFileSync: vi.fn() }
+})
+
 vi.mock('../../lib/auth.js', () => ({
   resolveAuth: vi.fn(() => ({ secretKey: 'sk_test_123', source: 'config' })),
   createClient: vi.fn(() => mockClient),
@@ -258,6 +263,256 @@ describe('factory: create command', () => {
   })
 })
 
+describe('factory: create --from-json', () => {
+  let readFileSyncMock: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    const fs = await import('node:fs')
+    readFileSyncMock = vi.mocked(fs.readFileSync)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('reads JSON body from file and passes to SDK', async () => {
+    readFileSyncMock.mockReturnValue(JSON.stringify({ amount: 10000, currency: 'CLP' }))
+
+    const mockResult = { serialize: () => ({ id: 'pi_123', amount: 10000 }) }
+    mockManager.create.mockResolvedValue(mockResult)
+
+    const program = createProgram()
+    await program.parseAsync(['payment_intents', 'create', '--from-json', 'payload.json'], {
+      from: 'user',
+    })
+
+    expect(readFileSyncMock).toHaveBeenCalledWith('payload.json', 'utf-8')
+    expect(mockManager.create).toHaveBeenCalledWith({ amount: 10000, currency: 'CLP' })
+    expect(success).toHaveBeenCalled()
+  })
+
+  test('reads JSON body from stdin when path is "-"', async () => {
+    readFileSyncMock.mockReturnValue(JSON.stringify({ amount: 5000, currency: 'MXN' }))
+
+    const mockResult = { serialize: () => ({ id: 'pi_456' }) }
+    mockManager.create.mockResolvedValue(mockResult)
+
+    const program = createProgram()
+    await program.parseAsync(['payment_intents', 'create', '--from-json', '-'], { from: 'user' })
+
+    expect(readFileSyncMock).toHaveBeenCalledWith(0, 'utf-8')
+    expect(mockManager.create).toHaveBeenCalledWith({ amount: 5000, currency: 'MXN' })
+  })
+
+  test('flags override JSON values', async () => {
+    readFileSyncMock.mockReturnValue(JSON.stringify({ amount: 10000, currency: 'CLP' }))
+
+    const mockResult = { serialize: () => ({ id: 'pi_789' }) }
+    mockManager.create.mockResolvedValue(mockResult)
+
+    const program = createProgram()
+    await program.parseAsync(
+      ['payment_intents', 'create', '--from-json', 'base.json', '--currency', 'MXN'],
+      { from: 'user' },
+    )
+
+    expect(mockManager.create).toHaveBeenCalledWith({
+      amount: 10000,
+      currency: 'MXN',
+    })
+  })
+
+  test('skips required flag validation when --from-json is provided', async () => {
+    readFileSyncMock.mockReturnValue(JSON.stringify({ amount: 10000, currency: 'CLP' }))
+
+    const mockResult = { serialize: () => ({ id: 'pi_abc' }) }
+    mockManager.create.mockResolvedValue(mockResult)
+
+    const program = createProgram()
+    await program.parseAsync(['payment_intents', 'create', '--from-json', 'payload.json'], {
+      from: 'user',
+    })
+
+    expect(error).not.toHaveBeenCalled()
+    expect(mockManager.create).toHaveBeenCalledWith({ amount: 10000, currency: 'CLP' })
+  })
+
+  test('JSON preserves extra fields not in createFlags', async () => {
+    readFileSyncMock.mockReturnValue(
+      JSON.stringify({
+        amount: 10000,
+        currency: 'CLP',
+        line_items: [{ name: 'Item 1', amount: 5000 }],
+        metadata: { order_id: 'ord_123' },
+      }),
+    )
+
+    const mockResult = { serialize: () => ({ id: 'pi_complex' }) }
+    mockManager.create.mockResolvedValue(mockResult)
+
+    const program = createProgram()
+    await program.parseAsync(['payment_intents', 'create', '--from-json', 'complex.json'], {
+      from: 'user',
+    })
+
+    expect(mockManager.create).toHaveBeenCalledWith({
+      amount: 10000,
+      currency: 'CLP',
+      line_items: [{ name: 'Item 1', amount: 5000 }],
+      metadata: { order_id: 'ord_123' },
+    })
+  })
+
+  test('deep merges nested flag values over JSON', async () => {
+    const nestedResource: ResourceDef = {
+      name: 'checkout_sessions',
+      displayName: 'checkout session',
+      cliCommand: 'checkout_sessions',
+      sdkMethod: 'paymentIntents',
+      sdkNamespace: 'v1',
+      verbs: ['create'],
+      priorityColumns: ['id'],
+      createFlags: [
+        { name: 'amount', type: 'number', required: true },
+        { name: 'currency', type: 'string', required: true },
+        {
+          name: 'recipient-account-type',
+          type: 'string',
+          nestedPath: 'payment_method_options.payment_intent.recipient_account.type',
+        },
+      ],
+      listFlags: [],
+    }
+
+    readFileSyncMock.mockReturnValue(
+      JSON.stringify({
+        amount: 5000,
+        currency: 'CLP',
+        payment_method_options: {
+          payment_intent: {
+            recipient_account: {
+              type: 'checking_account',
+              number: '12345678',
+            },
+          },
+        },
+      }),
+    )
+
+    const mockResult = { serialize: () => ({ id: 'cs_123' }) }
+    mockManager.create.mockResolvedValue(mockResult)
+
+    const program = createProgram(nestedResource)
+    await program.parseAsync(
+      [
+        'checkout_sessions',
+        'create',
+        '--from-json',
+        'base.json',
+        '--recipient-account-type',
+        'savings_account',
+      ],
+      { from: 'user' },
+    )
+
+    expect(mockManager.create).toHaveBeenCalledWith({
+      amount: 5000,
+      currency: 'CLP',
+      payment_method_options: {
+        payment_intent: {
+          recipient_account: {
+            type: 'savings_account',
+            number: '12345678',
+          },
+        },
+      },
+    })
+  })
+
+  describe('error cases', () => {
+    let exitSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+      exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('process.exit')
+      })
+    })
+
+    afterEach(() => {
+      exitSpy.mockRestore()
+    })
+
+    test('exits with error on invalid JSON', async () => {
+      readFileSyncMock.mockReturnValue('not valid json')
+
+      const program = createProgram()
+      await expect(
+        program.parseAsync(['payment_intents', 'create', '--from-json', 'bad.json'], {
+          from: 'user',
+        }),
+      ).rejects.toThrow('process.exit')
+
+      expect(error).toHaveBeenCalledWith(expect.stringContaining('invalid JSON'))
+    })
+
+    test('exits with error when file does not exist', async () => {
+      const enoent = new Error(
+        "ENOENT: no such file or directory, open 'missing.json'",
+      ) as Error & {
+        code: string
+      }
+      enoent.code = 'ENOENT'
+      readFileSyncMock.mockImplementation(() => {
+        throw enoent
+      })
+
+      const program = createProgram()
+      await expect(
+        program.parseAsync(['payment_intents', 'create', '--from-json', 'missing.json'], {
+          from: 'user',
+        }),
+      ).rejects.toThrow('process.exit')
+
+      expect(error).toHaveBeenCalledWith("--from-json: file 'missing.json' not found")
+    })
+
+    test('exits with error when stdin is a TTY', async () => {
+      const originalIsTTY = process.stdin.isTTY
+      Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+
+      const program = createProgram()
+      await expect(
+        program.parseAsync(['payment_intents', 'create', '--from-json', '-'], {
+          from: 'user',
+        }),
+      ).rejects.toThrow('process.exit')
+
+      expect(error).toHaveBeenCalledWith(
+        '--from-json -: no input on stdin. Pipe a file or use a path instead',
+      )
+
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: originalIsTTY,
+        configurable: true,
+      })
+    })
+
+    test('exits with error when JSON is not an object', async () => {
+      readFileSyncMock.mockReturnValue(JSON.stringify([1, 2, 3]))
+
+      const program = createProgram()
+      await expect(
+        program.parseAsync(['payment_intents', 'create', '--from-json', 'array.json'], {
+          from: 'user',
+        }),
+      ).rejects.toThrow('process.exit')
+
+      expect(error).toHaveBeenCalledWith('--from-json must contain a JSON object')
+    })
+  })
+})
+
 describe('factory: get command', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -394,7 +649,7 @@ describe('factory: delete command', () => {
     })
 
     const originalIsTTY = process.stdin.isTTY
-    process.stdin.isTTY = false
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true })
 
     const program = createProgram()
     await expect(
@@ -404,7 +659,7 @@ describe('factory: delete command', () => {
     expect(mockManager.delete).not.toHaveBeenCalled()
     expect(error).toHaveBeenCalledWith(expect.stringContaining('--yes'))
 
-    process.stdin.isTTY = originalIsTTY
+    Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
     exitSpy.mockRestore()
   })
 
@@ -413,7 +668,7 @@ describe('factory: delete command', () => {
     vi.mocked(confirm).mockResolvedValue(false)
 
     const originalIsTTY = process.stdin.isTTY
-    process.stdin.isTTY = true
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
 
     const program = createProgram()
     await program.parseAsync(['payment_intents', 'delete', 'pi_123'], { from: 'user' })
@@ -421,7 +676,7 @@ describe('factory: delete command', () => {
     expect(mockManager.delete).not.toHaveBeenCalled()
     expect(log).toHaveBeenCalledWith('Aborted.')
 
-    process.stdin.isTTY = originalIsTTY
+    Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
   })
 })
 

--- a/src/resources/factory.ts
+++ b/src/resources/factory.ts
@@ -1,6 +1,7 @@
 import type { Command } from 'commander'
 import type { Fintoc } from 'fintoc'
 import type { FlagDef, ResourceDef, SdkManager, Serializable } from '../types.js'
+import { readFileSync } from 'node:fs'
 import { confirm } from '@inquirer/prompts'
 import { createClient, resolveAuth } from '../lib/auth.js'
 import { readConfig } from '../lib/config.js'
@@ -87,6 +88,61 @@ const collectSetOptions = (cmd: Command, flags: FlagDef[]) => {
   return result
 }
 
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+  typeof v === 'object' && v !== null && !Array.isArray(v)
+
+// Deep merge two objects, where source values override target values
+const deepMerge = (
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+): Record<string, unknown> => {
+  const result = { ...target }
+  for (const key of Object.keys(source)) {
+    const sourceVal = source[key]
+    const targetVal = result[key]
+    if (isPlainObject(sourceVal) && isPlainObject(targetVal)) {
+      result[key] = deepMerge(targetVal, sourceVal)
+    } else {
+      result[key] = sourceVal
+    }
+  }
+  return result
+}
+
+// Read JSON body from file path or stdin ("-")
+const readJsonBody = (fromJson: string): Record<string, unknown> => {
+  if (fromJson === '-' && process.stdin.isTTY) {
+    error('--from-json -: no input on stdin. Pipe a file or use a path instead')
+    process.exit(1)
+  }
+
+  let raw: string
+  try {
+    raw = fromJson === '-' ? readFileSync(0, 'utf-8') : readFileSync(fromJson, 'utf-8')
+  } catch (err) {
+    if (err instanceof Error && 'code' in err && err.code === 'ENOENT') {
+      error(`--from-json: file '${fromJson}' not found`)
+      process.exit(1)
+    }
+    throw err
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    error(`--from-json: invalid JSON${fromJson !== '-' ? ` in ${fromJson}` : ''}`)
+    process.exit(1)
+  }
+
+  if (!isPlainObject(parsed)) {
+    error('--from-json must contain a JSON object')
+    process.exit(1)
+  }
+
+  return parsed as Record<string, unknown>
+}
+
 // Validate required flags are present
 const validateRequired = (cmd: Command, flags: FlagDef[], resourceName: string, verb: string) => {
   const opts = cmd.opts()
@@ -136,14 +192,25 @@ const serialize = (obj: unknown): Record<string, unknown> => {
 const registerCreate = (parent: Command, resource: ResourceDef) => {
   const cmd = parent.command('create').description(`Create a new ${resource.displayName}`)
 
+  cmd.option(
+    '--from-json <path>',
+    'Read request body from a JSON file (use "-" for stdin). JSON keys must match the API body format (see https://docs.fintoc.com)',
+  )
   addFlags(cmd, resource.createFlags ?? [])
 
   cmd.action(async (_opts: unknown, actionCmd: Command) => {
     const rootOpts = getRootOpts(actionCmd)
-    validateRequired(actionCmd, resource.createFlags ?? [], resource.cliCommand, 'create')
+    const localOpts = actionCmd.opts<{ fromJson?: string }>()
+
+    if (!localOpts.fromJson) {
+      validateRequired(actionCmd, resource.createFlags ?? [], resource.cliCommand, 'create')
+    }
 
     try {
-      const body = collectSetOptions(actionCmd, resource.createFlags ?? [])
+      const jsonBody = localOpts.fromJson ? readJsonBody(localOpts.fromJson) : {}
+      const flagBody = collectSetOptions(actionCmd, resource.createFlags ?? [])
+      const body = deepMerge(jsonBody, flagBody)
+
       const client = resolveClient(rootOpts, resource)
       const manager = getManager(client, resource)
 


### PR DESCRIPTION
## Contexto

Permitir crear recursos con payloads complejos (objetos anidados, `line_items`, `metadata`) sin depender solo de flags.

## Que hay de nuevo?

- [x] Flag `--from-json <path>` en todos los `create` (archivo o stdin)
- [x] Deep merge de JSON + flags, README actualizado

## Tests

- [x] Tests unitarios

Closes ONB-1819

<sup>*Created with Claude Code `/create-pr` command*</sup>