### PR TITLE
[ONB-1821] Refactor: extraer constantes y mejorar estructura de tests

### DIFF
--- a/src/commands/__tests__/doctor.test.ts
+++ b/src/commands/__tests__/doctor.test.ts
@@ -1,3 +1,4 @@
+import type { ExecSyncOptions } from 'node:child_process'
 import { Command } from 'commander'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { resolveAuth, whoami } from '../../lib/auth.js'
@@ -5,13 +6,19 @@ import { readConfig } from '../../lib/config.js'
 import { error, log, success, warn } from '../../lib/output.js'
 import { doctorCommand } from '../doctor.js'
 
+const { mockExecSync, mockExistsSync, mockStatSync } = vi.hoisted(() => ({
+  mockExecSync: vi.fn<(cmd: string, opts?: ExecSyncOptions) => string>(),
+  mockExistsSync: vi.fn<(path: string) => boolean>(),
+  mockStatSync: vi.fn(),
+}))
+
 vi.mock('node:child_process', () => ({
-  execSync: vi.fn(),
+  execSync: mockExecSync,
 }))
 
 vi.mock('node:fs', () => ({
-  existsSync: vi.fn(),
-  statSync: vi.fn(),
+  existsSync: mockExistsSync,
+  statSync: mockStatSync,
 }))
 
 vi.mock('../../lib/auth.js', () => ({
@@ -49,101 +56,111 @@ describe('doctor command', () => {
     vi.mocked(readConfig).mockReturnValue({})
   })
 
-  test('all checks pass', async () => {
-    const { execSync } = await import('node:child_process')
-    const { existsSync, statSync } = await import('node:fs')
-
-    vi.mocked(execSync).mockReturnValue('0.1.0\n')
-    vi.mocked(existsSync).mockReturnValue(true)
-    vi.mocked(statSync).mockReturnValue({ mode: 0o100600 } as ReturnType<typeof statSync>)
-    vi.mocked(resolveAuth).mockReturnValue({ secretKey: 'sk_test_abc123', source: 'config' })
-    vi.mocked(whoami).mockResolvedValue({
-      organizationName: 'Acme Corp',
-      mode: 'test',
-      apiVersion: '2023-03-15',
+  describe('when all checks pass', () => {
+    beforeEach(() => {
+      mockExecSync.mockReturnValue('0.1.0\n')
+      mockExistsSync.mockReturnValue(true)
+      mockStatSync.mockReturnValue({ mode: 0o100600 } as ReturnType<typeof mockStatSync>)
+      vi.mocked(resolveAuth).mockReturnValue({ secretKey: 'sk_test_abc123', source: 'config' })
+      vi.mocked(whoami).mockResolvedValue({
+        organizationName: 'Acme Corp',
+        mode: 'test',
+        apiVersion: '2023-03-15',
+      })
     })
 
-    const program = createProgram()
-    await program.parseAsync(['doctor'], { from: 'user' })
+    test('reports success for CLI version, config, API key, and connectivity', async () => {
+      const program = createProgram()
+      await program.parseAsync(['doctor'], { from: 'user' })
 
-    expect(success).toHaveBeenCalledWith(expect.stringContaining('CLI version'))
-    expect(success).toHaveBeenCalledWith(expect.stringContaining('Config file'))
-    expect(success).toHaveBeenCalledWith(expect.stringContaining('API key'))
-    expect(success).toHaveBeenCalledWith(expect.stringContaining('Connectivity'))
-    expect(success).toHaveBeenCalledWith(expect.stringContaining('Acme Corp'))
-    // JWS key is not configured in this test, so one error is expected
-    expect(error).toHaveBeenCalledTimes(1)
-    expect(error).toHaveBeenCalledWith(expect.stringContaining('JWS private key'))
-  })
-
-  test('no API key configured — skips connectivity', async () => {
-    const { execSync } = await import('node:child_process')
-    const { existsSync, statSync } = await import('node:fs')
-
-    vi.mocked(execSync).mockReturnValue('0.1.0\n')
-    vi.mocked(existsSync).mockReturnValue(true)
-    vi.mocked(statSync).mockReturnValue({ mode: 0o100600 } as ReturnType<typeof statSync>)
-    vi.mocked(resolveAuth).mockImplementation(() => {
-      throw new Error('No API key')
+      expect(success).toHaveBeenCalledWith(expect.stringContaining('CLI version'))
+      expect(success).toHaveBeenCalledWith(expect.stringContaining('Config file'))
+      expect(success).toHaveBeenCalledWith(expect.stringContaining('API key'))
+      expect(success).toHaveBeenCalledWith(expect.stringContaining('Connectivity'))
+      expect(success).toHaveBeenCalledWith(expect.stringContaining('Acme Corp'))
     })
 
-    const program = createProgram()
-    await program.parseAsync(['doctor'], { from: 'user' })
+    test('reports JWS key as not configured', async () => {
+      const program = createProgram()
+      await program.parseAsync(['doctor'], { from: 'user' })
 
-    expect(error).toHaveBeenCalledWith(expect.stringContaining('API key'))
-    expect(log).toHaveBeenCalledWith(expect.stringContaining('skipped'))
-    expect(whoami).not.toHaveBeenCalled()
+      expect(error).toHaveBeenCalledTimes(1)
+      expect(error).toHaveBeenCalledWith(expect.stringContaining('JWS private key'))
+    })
   })
 
-  test('API unreachable', async () => {
-    const { execSync } = await import('node:child_process')
-    const { existsSync, statSync } = await import('node:fs')
-
-    vi.mocked(execSync).mockReturnValue('0.1.0\n')
-    vi.mocked(existsSync).mockReturnValue(true)
-    vi.mocked(statSync).mockReturnValue({ mode: 0o100600 } as ReturnType<typeof statSync>)
-    vi.mocked(resolveAuth).mockReturnValue({ secretKey: 'sk_test_abc123', source: 'config' })
-    vi.mocked(whoami).mockRejectedValue(new Error('Network error'))
-
-    const program = createProgram()
-    await program.parseAsync(['doctor'], { from: 'user' })
-
-    expect(error).toHaveBeenCalledWith(expect.stringContaining('could not reach'))
-  })
-
-  test('outdated CLI version', async () => {
-    const { execSync } = await import('node:child_process')
-    const { existsSync, statSync } = await import('node:fs')
-
-    vi.mocked(execSync).mockReturnValue('0.2.0\n')
-    vi.mocked(existsSync).mockReturnValue(true)
-    vi.mocked(statSync).mockReturnValue({ mode: 0o100600 } as ReturnType<typeof statSync>)
-    vi.mocked(resolveAuth).mockReturnValue({ secretKey: 'sk_test_abc123', source: 'config' })
-    vi.mocked(whoami).mockResolvedValue({
-      organizationName: 'Acme Corp',
-      mode: 'test',
-      apiVersion: '2023-03-15',
+  describe('when API key is missing', () => {
+    beforeEach(() => {
+      mockExecSync.mockReturnValue('0.1.0\n')
+      mockExistsSync.mockReturnValue(true)
+      mockStatSync.mockReturnValue({ mode: 0o100600 } as ReturnType<typeof mockStatSync>)
+      vi.mocked(resolveAuth).mockImplementation(() => {
+        throw new Error('No API key')
+      })
     })
 
-    const program = createProgram()
-    await program.parseAsync(['doctor'], { from: 'user' })
+    test('skips connectivity checks', async () => {
+      const program = createProgram()
+      await program.parseAsync(['doctor'], { from: 'user' })
 
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('latest: 0.2.0'))
+      expect(error).toHaveBeenCalledWith(expect.stringContaining('API key'))
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('skipped'))
+      expect(whoami).not.toHaveBeenCalled()
+    })
   })
 
-  test('config file missing', async () => {
-    const { execSync } = await import('node:child_process')
-    const { existsSync } = await import('node:fs')
-
-    vi.mocked(execSync).mockReturnValue('0.1.0\n')
-    vi.mocked(existsSync).mockReturnValue(false)
-    vi.mocked(resolveAuth).mockImplementation(() => {
-      throw new Error('No API key')
+  describe('when API is unreachable', () => {
+    beforeEach(() => {
+      mockExecSync.mockReturnValue('0.1.0\n')
+      mockExistsSync.mockReturnValue(true)
+      mockStatSync.mockReturnValue({ mode: 0o100600 } as ReturnType<typeof mockStatSync>)
+      vi.mocked(resolveAuth).mockReturnValue({ secretKey: 'sk_test_abc123', source: 'config' })
+      vi.mocked(whoami).mockRejectedValue(new Error('Network error'))
     })
 
-    const program = createProgram()
-    await program.parseAsync(['doctor'], { from: 'user' })
+    test('reports connectivity error', async () => {
+      const program = createProgram()
+      await program.parseAsync(['doctor'], { from: 'user' })
 
-    expect(error).toHaveBeenCalledWith(expect.stringContaining('not found'))
+      expect(error).toHaveBeenCalledWith(expect.stringContaining('could not reach'))
+    })
+  })
+
+  describe('when CLI version is outdated', () => {
+    beforeEach(() => {
+      mockExecSync.mockReturnValue('0.2.0\n')
+      mockExistsSync.mockReturnValue(true)
+      mockStatSync.mockReturnValue({ mode: 0o100600 } as ReturnType<typeof mockStatSync>)
+      vi.mocked(resolveAuth).mockReturnValue({ secretKey: 'sk_test_abc123', source: 'config' })
+      vi.mocked(whoami).mockResolvedValue({
+        organizationName: 'Acme Corp',
+        mode: 'test',
+        apiVersion: '2023-03-15',
+      })
+    })
+
+    test('warns about newer version', async () => {
+      const program = createProgram()
+      await program.parseAsync(['doctor'], { from: 'user' })
+
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('latest: 0.2.0'))
+    })
+  })
+
+  describe('when config file is missing', () => {
+    beforeEach(() => {
+      mockExecSync.mockReturnValue('0.1.0\n')
+      mockExistsSync.mockReturnValue(false)
+      vi.mocked(resolveAuth).mockImplementation(() => {
+        throw new Error('No API key')
+      })
+    })
+
+    test('reports config file not found', async () => {
+      const program = createProgram()
+      await program.parseAsync(['doctor'], { from: 'user' })
+
+      expect(error).toHaveBeenCalledWith(expect.stringContaining('not found'))
+    })
   })
 })

--- a/src/commands/__tests__/login.test.ts
+++ b/src/commands/__tests__/login.test.ts
@@ -48,90 +48,102 @@ describe('login command', () => {
     process.stdin.isTTY = originalIsTTY
   })
 
-  test('authenticates successfully with interactive prompt', async () => {
-    vi.mocked(password).mockResolvedValue('sk_test_valid123')
-    vi.mocked(whoami).mockResolvedValue({
-      organizationName: 'Acme Corp',
-      mode: 'test',
-      apiVersion: '2023-03-15',
+  describe('when authenticating interactively', () => {
+    test('prompts for key, validates via whoami, and saves config', async () => {
+      vi.mocked(password).mockResolvedValue('sk_test_valid123')
+      vi.mocked(whoami).mockResolvedValue({
+        organizationName: 'Acme Corp',
+        mode: 'test',
+        apiVersion: '2023-03-15',
+      })
+
+      const program = createProgram()
+      await program.parseAsync(['login'], { from: 'user' })
+
+      expect(password).toHaveBeenCalled()
+      expect(whoami).toHaveBeenCalledWith('sk_test_valid123')
+      expect(readConfig).toHaveBeenCalled()
+      expect(writeConfig).toHaveBeenCalledWith({ secret_key: 'sk_test_valid123' })
+      expect(success).toHaveBeenCalledWith('Authenticated as Acme Corp (test mode)')
     })
 
-    const program = createProgram()
-    await program.parseAsync(['login'], { from: 'user' })
+    test('preserves existing config fields when writing', async () => {
+      vi.mocked(password).mockResolvedValue('sk_test_new')
+      vi.mocked(readConfig).mockReturnValue({ jws_private_key: '/path/to/key.pem' })
+      vi.mocked(whoami).mockResolvedValue({
+        organizationName: 'Acme Corp',
+        mode: 'test',
+        apiVersion: '2023-03-15',
+      })
 
-    expect(password).toHaveBeenCalled()
-    expect(whoami).toHaveBeenCalledWith('sk_test_valid123')
-    expect(readConfig).toHaveBeenCalled()
-    expect(writeConfig).toHaveBeenCalledWith({ secret_key: 'sk_test_valid123' })
-    expect(success).toHaveBeenCalledWith('Authenticated as Acme Corp (test mode)')
+      const program = createProgram()
+      await program.parseAsync(['login'], { from: 'user' })
+
+      expect(writeConfig).toHaveBeenCalledWith({
+        jws_private_key: '/path/to/key.pem',
+        secret_key: 'sk_test_new',
+      })
+    })
   })
 
-  test('preserves existing config fields when writing', async () => {
-    vi.mocked(password).mockResolvedValue('sk_test_new')
-    vi.mocked(readConfig).mockReturnValue({ jws_private_key: '/path/to/key.pem' })
-    vi.mocked(whoami).mockResolvedValue({
-      organizationName: 'Acme Corp',
-      mode: 'test',
-      apiVersion: '2023-03-15',
-    })
+  describe('when key validation fails', () => {
+    test('exits with error and does not save config', async () => {
+      vi.mocked(password).mockResolvedValue('sk_test_invalid')
+      vi.mocked(whoami).mockRejectedValue(new Error('Invalid API key'))
 
-    const program = createProgram()
-    await program.parseAsync(['login'], { from: 'user' })
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('process.exit')
+      })
 
-    expect(writeConfig).toHaveBeenCalledWith({
-      jws_private_key: '/path/to/key.pem',
-      secret_key: 'sk_test_new',
+      const program = createProgram()
+
+      await expect(program.parseAsync(['login'], { from: 'user' })).rejects.toThrow('process.exit')
+
+      expect(writeConfig).not.toHaveBeenCalled()
+      expect(error).toHaveBeenCalledWith('Invalid API key')
+
+      exitSpy.mockRestore()
     })
   })
 
-  test('exits with error on invalid key', async () => {
-    vi.mocked(password).mockResolvedValue('sk_test_invalid')
-    vi.mocked(whoami).mockRejectedValue(new Error('Invalid API key'))
-
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('process.exit')
+  describe('when running in non-TTY environment', () => {
+    beforeEach(() => {
+      process.stdin.isTTY = false as unknown as boolean
     })
 
-    const program = createProgram()
+    test('exits with error when --api-key is not provided', async () => {
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('process.exit')
+      })
 
-    await expect(program.parseAsync(['login'], { from: 'user' })).rejects.toThrow('process.exit')
+      const program = createProgram()
 
-    expect(writeConfig).not.toHaveBeenCalled()
-    expect(error).toHaveBeenCalledWith('Invalid API key')
+      await expect(program.parseAsync(['login'], { from: 'user' })).rejects.toThrow('process.exit')
 
-    exitSpy.mockRestore()
+      expect(error).toHaveBeenCalledWith(
+        'Non-interactive terminal detected. Pass the key via flag:',
+      )
+
+      exitSpy.mockRestore()
+    })
   })
 
-  test('exits with error on non-TTY without --api-key', async () => {
-    process.stdin.isTTY = false as unknown as boolean
+  describe('when using --api-key flag', () => {
+    test('skips prompt and authenticates directly', async () => {
+      vi.mocked(readConfig).mockReturnValue({})
+      vi.mocked(whoami).mockResolvedValue({
+        organizationName: 'Acme Corp',
+        mode: 'test',
+        apiVersion: '2023-03-15',
+      })
 
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('process.exit')
+      const program = createProgram()
+      await program.parseAsync(['login', '--api-key', 'sk_test_flag123'], { from: 'user' })
+
+      expect(password).not.toHaveBeenCalled()
+      expect(whoami).toHaveBeenCalledWith('sk_test_flag123')
+      expect(writeConfig).toHaveBeenCalledWith({ secret_key: 'sk_test_flag123' })
+      expect(success).toHaveBeenCalledWith('Authenticated as Acme Corp (test mode)')
     })
-
-    const program = createProgram()
-
-    await expect(program.parseAsync(['login'], { from: 'user' })).rejects.toThrow('process.exit')
-
-    expect(error).toHaveBeenCalledWith('Non-interactive terminal detected. Pass the key via flag:')
-
-    exitSpy.mockRestore()
-  })
-
-  test('authenticates with --api-key flag skipping prompt', async () => {
-    vi.mocked(readConfig).mockReturnValue({})
-    vi.mocked(whoami).mockResolvedValue({
-      organizationName: 'Acme Corp',
-      mode: 'test',
-      apiVersion: '2023-03-15',
-    })
-
-    const program = createProgram()
-    await program.parseAsync(['login', '--api-key', 'sk_test_flag123'], { from: 'user' })
-
-    expect(password).not.toHaveBeenCalled()
-    expect(whoami).toHaveBeenCalledWith('sk_test_flag123')
-    expect(writeConfig).toHaveBeenCalledWith({ secret_key: 'sk_test_flag123' })
-    expect(success).toHaveBeenCalledWith('Authenticated as Acme Corp (test mode)')
   })
 })

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -4,13 +4,14 @@ import { existsSync, statSync } from 'node:fs'
 
 import { maskKey, resolveAuth, whoami } from '../lib/auth.js'
 import { CONFIG_PATH, readConfig } from '../lib/config.js'
+import { API_HOST, NPM_PACKAGE_NAME } from '../lib/constants.js'
 import { error, log, success, warn } from '../lib/output.js'
 import { getCliVersion } from '../lib/version.js'
 
 const checkCliVersion = () => {
   const currentVersion = getCliVersion()
   try {
-    const latest = execSync('npm view @fintoc/cli version', {
+    const latest = execSync(`npm view ${NPM_PACKAGE_NAME} version`, {
       encoding: 'utf-8',
       timeout: 10_000,
     }).trim()
@@ -59,10 +60,10 @@ const checkApiKey = (options?: { apiKey?: string }) => {
 const checkConnectivity = async (secretKey: string) => {
   try {
     const info = await whoami(secretKey)
-    success(`Connectivity        api.fintoc.com reachable`)
+    success(`Connectivity        ${API_HOST} reachable`)
     success(`Organization        ${info.organizationName} (${info.mode} mode)`)
   } catch {
-    error('Connectivity        could not reach api.fintoc.com')
+    error(`Connectivity        could not reach ${API_HOST}`)
     log('                    Check your internet connection and API key')
   }
 }

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -1,9 +1,8 @@
 import type { Command } from 'commander'
 import { exec } from 'node:child_process'
 
+import { DASHBOARD_URL } from '../lib/constants.js'
 import { error, success } from '../lib/output.js'
-
-const DASHBOARD_URL = 'https://dashboard.fintoc.com/'
 
 const openInBrowser = (url: string): Promise<void> => {
   const commands: Record<string, string> = {

--- a/src/lib/__tests__/output.test.ts
+++ b/src/lib/__tests__/output.test.ts
@@ -12,7 +12,7 @@ import {
   warn,
 } from '../output.js'
 
-describe('output', () => {
+describe('console wrappers', () => {
   afterEach(() => {
     vi.restoreAllMocks()
   })
@@ -101,62 +101,68 @@ describe('printTable', () => {
     vi.restoreAllMocks()
   })
 
-  test('prints no results message for empty rows', () => {
-    const spy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    printTable({ columns: ['id'], rows: [] })
-    expect(spy).toHaveBeenCalledWith('No results found.')
+  describe('when rows are empty', () => {
+    test('prints no results message', () => {
+      const spy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      printTable({ columns: ['id'], rows: [] })
+      expect(spy).toHaveBeenCalledWith('No results found.')
+    })
   })
 
-  test('prints header and rows', () => {
-    const calls: string[] = []
-    vi.spyOn(console, 'log').mockImplementation((msg: string) => {
-      calls.push(msg)
+  describe('when rows have data', () => {
+    test('prints header and rows', () => {
+      const calls: string[] = []
+      vi.spyOn(console, 'log').mockImplementation((msg: string) => {
+        calls.push(msg)
+      })
+
+      printTable({
+        columns: ['id', 'status'],
+        rows: [
+          { id: 'pi_123', status: 'pending' },
+          { id: 'pi_456', status: 'succeeded' },
+        ],
+      })
+
+      expect(calls[0]).toContain('ID')
+      expect(calls[0]).toContain('STATUS')
+      expect(calls[1]).toContain('pi_123')
+      expect(calls[2]).toContain('pi_456')
+      expect(calls[4]).toContain('Showing 2 results')
     })
 
-    printTable({
-      columns: ['id', 'status'],
-      rows: [
-        { id: 'pi_123', status: 'pending' },
-        { id: 'pi_456', status: 'succeeded' },
-      ],
-    })
+    test('uses singular "result" for single row', () => {
+      const calls: string[] = []
+      vi.spyOn(console, 'log').mockImplementation((msg: string) => {
+        calls.push(msg)
+      })
 
-    expect(calls[0]).toContain('ID')
-    expect(calls[0]).toContain('STATUS')
-    expect(calls[1]).toContain('pi_123')
-    expect(calls[2]).toContain('pi_456')
-    expect(calls[4]).toContain('Showing 2 results')
+      printTable({
+        columns: ['id'],
+        rows: [{ id: 'pi_123' }],
+      })
+
+      const footer = calls.find((c) => c.includes('Showing'))
+      expect(footer).toContain('1 result')
+    })
   })
 
-  test('shows "X of Y" when total exceeds shown', () => {
-    const calls: string[] = []
-    vi.spyOn(console, 'log').mockImplementation((msg: string) => {
-      calls.push(msg)
+  describe('when total exceeds shown', () => {
+    test('shows "X of Y" in footer', () => {
+      const calls: string[] = []
+      vi.spyOn(console, 'log').mockImplementation((msg: string) => {
+        calls.push(msg)
+      })
+
+      printTable({
+        columns: ['id'],
+        rows: [{ id: 'pi_123' }],
+        total: 50,
+      })
+
+      const footer = calls.find((c) => c.includes('Showing'))
+      expect(footer).toContain('1 of 50')
     })
-
-    printTable({
-      columns: ['id'],
-      rows: [{ id: 'pi_123' }],
-      total: 50,
-    })
-
-    const footer = calls.find((c) => c.includes('Showing'))
-    expect(footer).toContain('1 of 50')
-  })
-
-  test('uses singular "result" for single row', () => {
-    const calls: string[] = []
-    vi.spyOn(console, 'log').mockImplementation((msg: string) => {
-      calls.push(msg)
-    })
-
-    printTable({
-      columns: ['id'],
-      rows: [{ id: 'pi_123' }],
-    })
-
-    const footer = calls.find((c) => c.includes('Showing'))
-    expect(footer).toContain('1 result')
   })
 })
 
@@ -177,29 +183,33 @@ describe('printDetail', () => {
     vi.restoreAllMocks()
   })
 
-  test('prints key-value pairs', () => {
-    const calls: string[] = []
-    vi.spyOn(console, 'log').mockImplementation((msg: string) => {
-      calls.push(msg)
+  describe('rendering', () => {
+    test('prints key-value pairs', () => {
+      const calls: string[] = []
+      vi.spyOn(console, 'log').mockImplementation((msg: string) => {
+        calls.push(msg)
+      })
+
+      printDetail({ id: 'pi_123', amount: 10000 })
+
+      expect(calls[0]).toContain('id')
+      expect(calls[0]).toContain('pi_123')
+      expect(calls[1]).toContain('amount')
+      expect(calls[1]).toContain('10000')
     })
-
-    printDetail({ id: 'pi_123', amount: 10000 })
-
-    expect(calls[0]).toContain('id')
-    expect(calls[0]).toContain('pi_123')
-    expect(calls[1]).toContain('amount')
-    expect(calls[1]).toContain('10000')
   })
 
-  test('respects column filter', () => {
-    const calls: string[] = []
-    vi.spyOn(console, 'log').mockImplementation((msg: string) => {
-      calls.push(msg)
+  describe('when column filter is provided', () => {
+    test('only shows filtered columns', () => {
+      const calls: string[] = []
+      vi.spyOn(console, 'log').mockImplementation((msg: string) => {
+        calls.push(msg)
+      })
+
+      printDetail({ id: 'pi_123', amount: 10000, secret: 'hidden' }, ['id', 'amount'])
+
+      expect(calls).toHaveLength(2)
+      expect(calls.every((c) => !c.includes('hidden'))).toBe(true)
     })
-
-    printDetail({ id: 'pi_123', amount: 10000, secret: 'hidden' }, ['id', 'amount'])
-
-    expect(calls).toHaveLength(2)
-    expect(calls.every((c) => !c.includes('hidden'))).toBe(true)
   })
 })

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,7 @@
+export const API_HOST = 'api.fintoc.com'
+export const NPM_PACKAGE_NAME = '@fintoc/cli'
+export const DEFAULT_LIST_LIMIT = 10
+
+export const DASHBOARD_URL = 'https://dashboard.fintoc.com/'
+export const DASHBOARD_API_KEYS_URL = 'https://dashboard.fintoc.com/api-keys'
+export const DOCS_TRANSFERS_URL = 'https://docs.fintoc.com/docs/transfers'

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,3 +1,4 @@
+import { API_HOST, DASHBOARD_API_KEYS_URL, DOCS_TRANSFERS_URL } from './constants.js'
 import { error, log } from './output.js'
 
 type ErrorContext = {
@@ -95,14 +96,14 @@ export const handleError = (err: unknown, context?: ErrorContext): never => {
       'Or:    export FINTOC_SECRET_KEY=sk_test_...',
       'Or:    fintoc --api-key sk_test_... <command>',
       '',
-      'Get your API keys at: https://dashboard.fintoc.com/api-keys',
+      `Get your API keys at: ${DASHBOARD_API_KEYS_URL}`,
     ])
     return process.exit(1)
   }
 
   // Network / connectivity failure
   if (isConnectivityError(err)) {
-    error('Could not connect to api.fintoc.com')
+    error(`Could not connect to ${API_HOST}`)
     printNextSteps(['Check your internet connection, or run: fintoc doctor'])
     return process.exit(1)
   }
@@ -113,7 +114,7 @@ export const handleError = (err: unknown, context?: ErrorContext): never => {
     printNextSteps([
       'Set it with:  fintoc config set jws_private_key <path>',
       'Or pass:      --jws-private-key <path>',
-      'More info:    https://docs.fintoc.com/docs/transfers',
+      `More info:    ${DOCS_TRANSFERS_URL}`,
     ])
     return process.exit(1)
   }
@@ -137,7 +138,7 @@ export const handleError = (err: unknown, context?: ErrorContext): never => {
       error(`Authentication failed: ${fields.message ?? 'Invalid API key'}`)
       printNextSteps([
         'Check your API key and try again.',
-        'Get your API keys at: https://dashboard.fintoc.com/api-keys',
+        `Get your API keys at: ${DASHBOARD_API_KEYS_URL}`,
       ])
       return process.exit(1)
     }

--- a/src/resources/factory.ts
+++ b/src/resources/factory.ts
@@ -5,6 +5,7 @@ import { readFileSync } from 'node:fs'
 import { confirm } from '@inquirer/prompts'
 import { createClient, resolveAuth } from '../lib/auth.js'
 import { readConfig } from '../lib/config.js'
+import { DEFAULT_LIST_LIMIT } from '../lib/constants.js'
 import { handleError } from '../lib/errors.js'
 import { error, log, printDetail, printJson, printTable, success } from '../lib/output.js'
 
@@ -258,7 +259,7 @@ const registerList = (parent: Command, resource: ResourceDef) => {
   const cmd = parent
     .command('list')
     .description(`List ${resource.name.replace(/_/g, ' ')}`)
-    .option('--limit <number>', 'Max results to show', '10')
+    .option('--limit <number>', 'Max results to show', String(DEFAULT_LIST_LIMIT))
 
   addFlags(cmd, resource.listFlags ?? [])
 


### PR DESCRIPTION
## Contexto

Refactor menor para reducir duplicación de strings y mejorar la organización de los tests existentes.

## Que hay de nuevo?

- [x] Nuevo módulo `lib/constants.ts` centraliza URLs, nombres y valores por defecto
- [x] Tests reestructurados con bloques `describe` y mocks hoisted

<sup>*Created with Claude Code `/create-pr` command*</sup>