### PR TITLE
[ONB-1822] Agregar subcomando fintoc config set

### DIFF
--- a/src/commands/__tests__/config.test.ts
+++ b/src/commands/__tests__/config.test.ts
@@ -1,7 +1,8 @@
 import { Command } from 'commander'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { resolveAuth, whoami } from '../../lib/auth.js'
-import { log, warn } from '../../lib/output.js'
+import { readConfig, writeConfig } from '../../lib/config.js'
+import { error, log, success, warn } from '../../lib/output.js'
 import { configCommand } from '../config.js'
 
 vi.mock('../../lib/auth.js', () => ({
@@ -12,6 +13,8 @@ vi.mock('../../lib/auth.js', () => ({
 
 vi.mock('../../lib/config.js', () => ({
   CONFIG_PATH: '/mock-home/.fintoc/config.toml',
+  readConfig: vi.fn(),
+  writeConfig: vi.fn(),
 }))
 
 vi.mock('../../lib/output.js', () => ({
@@ -76,5 +79,71 @@ describe('config command', () => {
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('Unable to reach Fintoc API'))
     expect(log).toHaveBeenCalledWith(expect.stringContaining('(unknown)'))
     expect(log).toHaveBeenCalledWith(expect.stringContaining('env var'))
+  })
+})
+
+describe('config set command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('sets jws_private_key in config', async () => {
+    vi.mocked(readConfig).mockReturnValue({ secret_key: 'sk_test_abc123' })
+
+    const program = createProgram()
+    await program.parseAsync(['config', 'set', 'jws_private_key', '/path/to/key.pem'], {
+      from: 'user',
+    })
+
+    expect(writeConfig).toHaveBeenCalledWith({
+      secret_key: 'sk_test_abc123',
+      jws_private_key: '/path/to/key.pem',
+    })
+    expect(success).toHaveBeenCalledWith('Config updated: jws_private_key')
+  })
+
+  test('sets secret_key in config', async () => {
+    vi.mocked(readConfig).mockReturnValue({})
+
+    const program = createProgram()
+    await program.parseAsync(['config', 'set', 'secret_key', 'sk_test_newkey'], {
+      from: 'user',
+    })
+
+    expect(writeConfig).toHaveBeenCalledWith({ secret_key: 'sk_test_newkey' })
+    expect(success).toHaveBeenCalledWith('Config updated: secret_key')
+  })
+
+  test('rejects unknown config keys', async () => {
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new Error(`exit ${code}`)
+    })
+
+    const program = createProgram()
+    await expect(
+      program.parseAsync(['config', 'set', 'unknown_key', 'value'], { from: 'user' }),
+    ).rejects.toThrow('exit 1')
+
+    expect(error).toHaveBeenCalledWith(expect.stringContaining("Unknown config key: 'unknown_key'"))
+    expect(writeConfig).not.toHaveBeenCalled()
+
+    mockExit.mockRestore()
+  })
+
+  test('preserves existing config values when setting a new key', async () => {
+    vi.mocked(readConfig).mockReturnValue({
+      secret_key: 'sk_test_existing',
+      jws_private_key: '/old/path.pem',
+    })
+
+    const program = createProgram()
+    await program.parseAsync(['config', 'set', 'jws_private_key', '/new/path.pem'], {
+      from: 'user',
+    })
+
+    expect(writeConfig).toHaveBeenCalledWith({
+      secret_key: 'sk_test_existing',
+      jws_private_key: '/new/path.pem',
+    })
   })
 })

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,13 +1,20 @@
 import type { Command } from 'commander'
-
+import type { FintocConfig } from '../types.js'
 import { maskKey, resolveAuth, whoami } from '../lib/auth.js'
-import { CONFIG_PATH } from '../lib/config.js'
-import { log, warn } from '../lib/output.js'
+import { CONFIG_PATH, readConfig, writeConfig } from '../lib/config.js'
+import { error, log, success, warn } from '../lib/output.js'
+
+const ALLOWED_KEYS: readonly string[] = [
+  'secret_key',
+  'jws_private_key',
+] satisfies readonly (keyof FintocConfig)[]
+
+const isConfigKey = (key: string): key is keyof FintocConfig => ALLOWED_KEYS.includes(key)
 
 export const configCommand = (program: Command) => {
-  program
+  const configCmd = program
     .command('config')
-    .description('Show current configuration')
+    .description('Show or update CLI configuration')
     .action(async (_opts: unknown, cmd: Command) => {
       let secretKey: string
       let source: string
@@ -50,5 +57,25 @@ export const configCommand = (program: Command) => {
       log(`  API version:   ${apiVersion}`)
       log(`  Config path:   ${CONFIG_PATH}`)
       log(`  Source:        ${source}`)
+    })
+
+  configCmd
+    .command('set <key> <value>')
+    .description('Set a config value (allowed keys: secret_key, jws_private_key)')
+    .action((key: string, value: string) => {
+      if (!isConfigKey(key)) {
+        error(`Unknown config key: '${key}'`)
+        log('')
+        log(`  Allowed keys: ${ALLOWED_KEYS.join(', ')}`)
+        log(`  Example: fintoc config set jws_private_key /path/to/key.pem`)
+        process.exit(1)
+      }
+
+      const config = readConfig()
+      config[key] = value
+      writeConfig(config)
+
+      success(`Config updated: ${key}`)
+      log(`  Saved to ${CONFIG_PATH}`)
     })
 }


### PR DESCRIPTION
## Contexto

Necesario para configurar la JWS private key requerida por transfers.

## Que hay de nuevo?

- [x] Subcomando `fintoc config set <key> <value>` con validación de keys permitidas para agregar la JWS Key

## Tests

- [x] Tests unitarios para `config set`
- [x] Pruebas en local e2e


<sup>*Created with Claude Code `/create-pr` command*</sup>