### PR TITLE
[ONB-1833] Feat: namespace explícito v2 para transfers y accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ fintoc login
 # List payment intents
 fintoc payment_intents list
 
+# List transfers (v2 resource)
+fintoc v2 transfers list
+
 # Create a charge from a JSON file
 fintoc charges create --from-json payload.json
 
@@ -53,11 +56,13 @@ fintoc logout
 
 ## Resources
 
+Resources map to `fintoc <resource> <action> [flags]`. V2 API resources require the `v2` prefix: `fintoc v2 <resource> <action> [flags]`.
+
+### V1 resources
+
 | Resource | create | get | list | delete | expire |
 |----------|:------:|:---:|:----:|:------:|:------:|
 | `payment_intents` | | ✔ | ✔ | | |
-| `transfers` | ✔ | ✔ | ✔ | | |
-| `accounts` | | ✔ | ✔ | | |
 | `webhook_endpoints` | ✔ | ✔ | ✔ | ✔ | |
 | `charges` | ✔ | ✔ | ✔ | | |
 | `subscriptions` | | ✔ | ✔ | | |
@@ -65,17 +70,50 @@ fintoc logout
 | `checkout_sessions` | ✔ | ✔ | | | ✔ |
 | `api_keys` | | | ✔ | | |
 
+### V2 resources (require `v2` prefix)
+
+| Resource | create | get | list |
+|----------|:------:|:---:|:----:|
+| `transfers` | ✔ | ✔ | ✔ |
+| `accounts` | | ✔ | ✔ |
+
+### Command patterns
+
+```bash
+# get — fetch a single resource by ID
+fintoc <resource> get <id>
+fintoc v2 <resource> get <id>
+
+# list — list resources with optional filters
+fintoc <resource> list [--status <value>] [--since <date>] [--until <date>] [--limit <n>]
+fintoc v2 <resource> list [--status <value>] [--limit <n>]
+
+# create — create a resource with flags or JSON
+fintoc <resource> create --<flag> <value> ...
+fintoc <resource> create --from-json <file|->
+
+# delete — delete a resource (webhook_endpoints, links)
+fintoc <resource> delete <id> [--yes]
+
+# expire — expire a resource (checkout_sessions)
+fintoc <resource> expire <id> [--yes]
+```
+
 ### Examples
 
 ```bash
 # Get a resource by ID
 fintoc payment_intents get pi_test_abc123
 
-# List with filters
-fintoc charges list --status succeeded --since 2026-01-01
+# List with filters (comma-separated for multiple values)
+fintoc charges list --status succeeded,failed --since 2026-01-01
 
-# Create with flags
-fintoc transfers create --amount 10000 --currency CLP --counterparty-account-number 12345678
+# Create a v2 transfer
+fintoc v2 transfers create --amount 10000 --currency CLP \
+  --account-id acc_test_abc123 \
+  --counterparty-account-number 12345678 \
+  --counterparty-institution-id cl_banco_estado \
+  --jws-private-key ~/path/to/private_key.pem
 
 # Create from a JSON file
 fintoc checkout_sessions create --from-json session.json
@@ -96,7 +134,16 @@ By default the CLI prints a formatted table. Use `--json` for machine-readable o
 
 ```bash
 fintoc payment_intents list --json
-fintoc charges get ch_test_abc123 --json
+fintoc v2 accounts get acc_test_abc123 --json
+```
+
+### Discovering flags
+
+Each command exposes its available flags via `--help`:
+
+```bash
+fintoc charges create --help
+fintoc v2 transfers list --help
 ```
 
 ## Utilities

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { loginCommand } from './commands/login.js'
 import { logoutCommand } from './commands/logout.js'
 import { openCommand } from './commands/open.js'
 import { registerResourceCommands } from './resources/factory.js'
-import { resources } from './resources/registry.js'
+import { v1Resources, v2Resources } from './resources/registry.js'
 
 declare const __CLI_VERSION__: string
 
@@ -30,7 +30,38 @@ logoutCommand(program)
 configCommand(program)
 doctorCommand(program)
 openCommand(program)
-registerResourceCommands(program, resources)
+registerResourceCommands(program, v1Resources)
+
+const v2Cmd = program.command('v2').description('API v2 resources')
+registerResourceCommands(v2Cmd, v2Resources)
+
+type HelpEntry = { name: () => string; description: () => string }
+
+const formatGroup = (
+  lines: string[],
+  title: string,
+  entries: readonly HelpEntry[],
+  padWidth: number,
+) => {
+  if (entries.length === 0) {
+    return
+  }
+  lines.push('')
+  lines.push(`${title}:`)
+  for (const entry of entries) {
+    lines.push(`  ${entry.name().padEnd(padWidth)}${entry.description()}`)
+  }
+}
+
+const formatOptions = (lines: string[], cmd: Command, helper: Help) => {
+  lines.push('')
+  lines.push('Flags:')
+  const options = helper.visibleOptions(cmd)
+  const optPadWidth = Math.max(...options.map((o) => helper.optionTerm(o).length), 0) + 2
+  for (const opt of options) {
+    lines.push(`  ${helper.optionTerm(opt).padEnd(optPadWidth)}${opt.description}`)
+  }
+}
 
 program.configureHelp({
   formatHelp: (cmd: Command, helper: Help) => {
@@ -41,39 +72,54 @@ program.configureHelp({
     lines.push(`Usage: ${cmd.name()} <command> [flags]`)
 
     const subcommands = cmd.commands
-    const padWidth = Math.max(...subcommands.map((c) => c.name().length), 0) + 2
 
-    const formatGroup = (title: string, cmds: Command[]) => {
-      if (cmds.length === 0) {
-        return
-      }
-      lines.push('')
-      lines.push(`${title}:`)
-      for (const c of cmds) {
-        lines.push(`  ${c.name().padEnd(padWidth)}${c.description()}`)
-      }
-    }
-
-    const authCmds = subcommands.filter((c) => AUTH_COMMANDS.has(c.name()))
-    const utilityCmds = subcommands.filter((c) => UTILITY_COMMANDS.has(c.name()))
-    const resourceCmds = subcommands.filter(
-      (c) => !AUTH_COMMANDS.has(c.name()) && !UTILITY_COMMANDS.has(c.name()),
+    const authEntries = subcommands.filter((c) => AUTH_COMMANDS.has(c.name()))
+    const utilityEntries = subcommands.filter((c) => UTILITY_COMMANDS.has(c.name()))
+    const v1ResourceEntries = subcommands.filter(
+      (c) => !AUTH_COMMANDS.has(c.name()) && !UTILITY_COMMANDS.has(c.name()) && c.name() !== 'v2',
     )
 
-    formatGroup('Auth', authCmds)
-    formatGroup('Resources', resourceCmds)
-    formatGroup('Utilities', utilityCmds)
+    // Build v2 resource entries as "v2 <resource>" for display in help
+    const v2Group = subcommands.find((c) => c.name() === 'v2')
+    const v2ResourceEntries: HelpEntry[] = v2Group
+      ? v2Group.commands.map((c) => ({
+          name: () => `v2 ${c.name()}`,
+          description: () => c.description(),
+        }))
+      : []
 
-    lines.push('')
-    lines.push('Flags:')
-    const options = helper.visibleOptions(cmd)
-    const optPadWidth = Math.max(...options.map((o) => helper.optionTerm(o).length), 0) + 2
-    for (const opt of options) {
-      lines.push(`  ${helper.optionTerm(opt).padEnd(optPadWidth)}${opt.description}`)
-    }
+    const resourceEntries = [...v1ResourceEntries, ...v2ResourceEntries]
+    const allEntries = [...authEntries, ...resourceEntries, ...utilityEntries]
+    const padWidth = Math.max(...allEntries.map((e) => e.name().length), 0) + 2
+
+    formatGroup(lines, 'Auth', authEntries, padWidth)
+    formatGroup(lines, 'Resources', resourceEntries, padWidth)
+    formatGroup(lines, 'Utilities', utilityEntries, padWidth)
+
+    formatOptions(lines, cmd, helper)
 
     lines.push('')
     lines.push('Get started: fintoc login')
+    lines.push('')
+
+    return lines.join('\n')
+  },
+})
+
+v2Cmd.configureHelp({
+  formatHelp: (cmd: Command, helper: Help) => {
+    const lines: string[] = []
+
+    lines.push(cmd.description())
+    lines.push('')
+    lines.push(`Usage: fintoc v2 <resource> <action> [flags]`)
+
+    const entries = cmd.commands
+    const padWidth = Math.max(...entries.map((e) => e.name().length), 0) + 2
+
+    formatGroup(lines, 'Resources', entries, padWidth)
+
+    formatOptions(lines, cmd, helper)
     lines.push('')
 
     return lines.join('\n')

--- a/src/lib/__tests__/errors.test.ts
+++ b/src/lib/__tests__/errors.test.ts
@@ -104,7 +104,7 @@ describe('handleError', () => {
       })
 
       expect(() =>
-        handleError(err, { resourceName: 'payment_intents', verb: 'get', id: 'pi_invalid' }),
+        handleError(err, { cliPath: 'payment_intents', verb: 'get', id: 'pi_invalid' }),
       ).toThrow('process.exit')
 
       expect(error).toHaveBeenCalledWith("Error (404): 'pi_invalid' not found")
@@ -119,7 +119,7 @@ describe('handleError', () => {
         message: 'No such payment_intent: pi_invalid',
       })
 
-      expect(() => handleError(err, { resourceName: 'payment_intents', verb: 'get' })).toThrow(
+      expect(() => handleError(err, { cliPath: 'payment_intents', verb: 'get' })).toThrow(
         'process.exit',
       )
 
@@ -196,7 +196,7 @@ describe('handleError', () => {
       }
 
       expect(() =>
-        handleError(err, { resourceName: 'payment_intents', verb: 'get', id: 'pi_bad' }),
+        handleError(err, { cliPath: 'payment_intents', verb: 'get', id: 'pi_bad' }),
       ).toThrow('process.exit')
 
       expect(error).toHaveBeenCalledWith("Error (404): 'pi_bad' not found")

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -2,7 +2,7 @@ import { API_HOST, DASHBOARD_API_KEYS_URL, DOCS_TRANSFERS_URL } from './constant
 import { error, log } from './output.js'
 
 type ErrorContext = {
-  resourceName?: string
+  cliPath?: string
   verb?: string
   id?: string
 }
@@ -133,8 +133,8 @@ export const handleError = (err: unknown, context?: ErrorContext): never => {
     if (fields.code === 'missing_resource') {
       const label = context?.id ? `'${context.id}' not found` : 'Resource not found'
       error(`Error (404): ${label}`)
-      if (context?.resourceName) {
-        printNextSteps([`List available: fintoc ${context.resourceName} list`])
+      if (context?.cliPath) {
+        printNextSteps([`List available: fintoc ${context.cliPath} list`])
       }
       return process.exit(1)
     }

--- a/src/resources/__tests__/factory.test.ts
+++ b/src/resources/__tests__/factory.test.ts
@@ -786,33 +786,67 @@ describe('factory: --jws-private-key flag', () => {
 })
 
 describe('factory: v2 namespace', () => {
-  beforeEach(() => {
+  const v2Manager = {
+    list: vi.fn(),
+  }
+
+  const v2Resource: ResourceDef = {
+    name: 'transfers',
+    displayName: 'transfer',
+    cliCommand: 'transfers',
+    sdkMethod: 'transfers',
+    sdkNamespace: 'v2',
+    verbs: ['list'],
+    priorityColumns: ['id', 'amount', 'status'],
+    listFlags: [],
+  }
+
+  beforeEach(async () => {
     vi.clearAllMocks()
-  })
 
-  test('uses v2 namespace for v2 resources', async () => {
-    const v2Manager = { list: vi.fn().mockResolvedValue(asyncGenerator([])) }
-    const v2Client = {
-      v2: { transfers: v2Manager },
-    }
-
+    const v2Client = { v2: { transfers: v2Manager } }
     const { createClient } = await import('../../lib/auth.js')
     vi.mocked(createClient).mockReturnValue(v2Client as unknown as ReturnType<typeof createClient>)
+  })
 
-    const v2Resource: ResourceDef = {
-      name: 'transfers',
-      displayName: 'transfer',
-      cliCommand: 'transfers',
-      sdkMethod: 'transfers',
-      sdkNamespace: 'v2',
-      verbs: ['list'],
-      priorityColumns: ['id', 'amount', 'status'],
-      listFlags: [],
+  describe('when registered directly on a program', () => {
+    test('routes to the v2 SDK namespace', async () => {
+      v2Manager.list.mockResolvedValue(asyncGenerator([]))
+
+      const program = createProgram(v2Resource)
+      await program.parseAsync(['transfers', 'list'], { from: 'user' })
+
+      expect(v2Manager.list).toHaveBeenCalled()
+    })
+  })
+
+  describe('when nested under a v2 subcommand (root > v2 > resource > action)', () => {
+    const createV2Program = () => {
+      const root = new Command()
+      root.exitOverride()
+      root.option('--api-key <key>', 'Override API key').option('--json', 'Output as JSON')
+      const v2Cmd = root.command('v2').description('API v2 resources')
+      registerResourceCommands(v2Cmd, [v2Resource])
+      return root
     }
 
-    const program = createProgram(v2Resource)
-    await program.parseAsync(['transfers', 'list'], { from: 'user' })
+    test('routes to the v2 SDK namespace', async () => {
+      v2Manager.list.mockResolvedValue(asyncGenerator([]))
 
-    expect(v2Manager.list).toHaveBeenCalled()
+      const program = createV2Program()
+      await program.parseAsync(['v2', 'transfers', 'list'], { from: 'user' })
+
+      expect(v2Manager.list).toHaveBeenCalled()
+    })
+
+    test('resolves root --json flag through nested commands', async () => {
+      v2Manager.list.mockResolvedValue(asyncGenerator([{ serialize: () => ({ id: 'tr_1' }) }]))
+
+      const program = createV2Program()
+      await program.parseAsync(['--json', 'v2', 'transfers', 'list'], { from: 'user' })
+
+      expect(printJson).toHaveBeenCalledWith([{ id: 'tr_1' }])
+      expect(printTable).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/resources/__tests__/factory.test.ts
+++ b/src/resources/__tests__/factory.test.ts
@@ -186,6 +186,27 @@ describe('factory: create command', () => {
     exitSpy.mockRestore()
   })
 
+  test('shows v2 prefix in usage hint for v2 resources', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit')
+    })
+
+    const v2Resource: ResourceDef = {
+      ...testResource,
+      name: 'transfers',
+      cliCommand: 'transfers',
+      sdkNamespace: 'v2',
+    }
+
+    const program = createProgram(v2Resource)
+    await expect(
+      program.parseAsync(['transfers', 'create', '--currency', 'CLP'], { from: 'user' }),
+    ).rejects.toThrow('process.exit')
+
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('fintoc v2 transfers create'))
+    exitSpy.mockRestore()
+  })
+
   test('outputs JSON when --json flag is set', async () => {
     const mockResult = { serialize: () => ({ id: 'pi_123', amount: 10000 }) }
     mockManager.create.mockResolvedValue(mockResult)

--- a/src/resources/__tests__/registry.test.ts
+++ b/src/resources/__tests__/registry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 
-import { resources } from '../registry.js'
+import { resources, v1Resources, v2Resources } from '../registry.js'
 
 describe('resource registry', () => {
   test('contains all 9 resources', () => {
@@ -78,10 +78,20 @@ describe('resource registry', () => {
     })
 
     test('all other resources use v1 namespace', () => {
-      const v1Resources = resources.filter((r) => !['transfers', 'accounts'].includes(r.name))
-      for (const resource of v1Resources) {
+      const nonV2 = resources.filter((r) => !['transfers', 'accounts'].includes(r.name))
+      for (const resource of nonV2) {
         expect(resource.sdkNamespace).toBe('v1')
       }
+    })
+
+    test('v1Resources contains only v1 namespace resources', () => {
+      expect(v1Resources.every((r) => r.sdkNamespace === 'v1')).toBe(true)
+      expect(v1Resources).toHaveLength(7)
+    })
+
+    test('v2Resources contains only v2 namespace resources', () => {
+      expect(v2Resources.every((r) => r.sdkNamespace === 'v2')).toBe(true)
+      expect(v2Resources.map((r) => r.name)).toEqual(['transfers', 'accounts'])
     })
   })
 

--- a/src/resources/factory.ts
+++ b/src/resources/factory.ts
@@ -20,8 +20,18 @@ const toCamelCase = (str: string) => str.replace(/-([a-z])/g, (_, c: string) => 
 // Convert kebab-case flag name to snake_case for SDK
 const toSnakeCase = (str: string) => str.replace(/-/g, '_')
 
-// Get root program opts from a nested action command
-const getRootOpts = (actionCmd: Command) => actionCmd.parent!.parent!.opts<RootOpts>()
+// Get root program opts from a nested action command (walks up regardless of nesting depth)
+const getRootOpts = (actionCmd: Command) => {
+  let cmd = actionCmd
+  while (cmd.parent) {
+    cmd = cmd.parent
+  }
+  return cmd.opts<RootOpts>()
+}
+
+// Full CLI path for a resource, including v2 prefix when applicable
+const resourceCliPath = (resource: ResourceDef) =>
+  resource.sdkNamespace === 'v2' ? `v2 ${resource.cliCommand}` : resource.cliCommand
 
 // Get the SDK manager for a resource
 const getManager = (client: Fintoc, resource: ResourceDef) => {
@@ -145,7 +155,7 @@ const readJsonBody = (fromJson: string): Record<string, unknown> => {
 }
 
 // Validate required flags are present
-const validateRequired = (cmd: Command, flags: FlagDef[], resourceName: string, verb: string) => {
+const validateRequired = (cmd: Command, flags: FlagDef[], fullCliPath: string, verb: string) => {
   const opts = cmd.opts()
   const missing = flags
     .filter((f) => f.required && opts[toCamelCase(f.name)] === undefined)
@@ -155,12 +165,12 @@ const validateRequired = (cmd: Command, flags: FlagDef[], resourceName: string, 
     error(`Missing required ${missing.length === 1 ? 'flag' : 'flags'}: ${missing.join(', ')}`)
     log('')
     log(
-      `  Usage: fintoc ${resourceName} ${verb} ${flags
+      `  Usage: fintoc ${fullCliPath} ${verb} ${flags
         .filter((f) => f.required)
         .map((f) => `--${f.name} <${f.type}>`)
         .join(' ')}`,
     )
-    log(`  Help:  fintoc ${resourceName} ${verb} --help`)
+    log(`  Help:  fintoc ${fullCliPath} ${verb} --help`)
     process.exit(1)
   }
 }
@@ -209,7 +219,7 @@ const registerCreate = (parent: Command, resource: ResourceDef) => {
     const localOpts = actionCmd.opts<{ fromJson?: string; jwsPrivateKey?: string }>()
 
     if (!localOpts.fromJson) {
-      validateRequired(actionCmd, resource.createFlags ?? [], resource.cliCommand, 'create')
+      validateRequired(actionCmd, resource.createFlags ?? [], resourceCliPath(resource), 'create')
     }
 
     try {
@@ -231,7 +241,7 @@ const registerCreate = (parent: Command, resource: ResourceDef) => {
         printDetail(data, resource.priorityColumns)
       }
     } catch (err) {
-      handleError(err, { resourceName: resource.cliCommand, verb: 'create' })
+      handleError(err, { cliPath: resourceCliPath(resource), verb: 'create' })
     }
   })
 }
@@ -255,7 +265,7 @@ const registerGet = (parent: Command, resource: ResourceDef) => {
           printDetail(data, resource.priorityColumns)
         }
       } catch (err) {
-        handleError(err, { resourceName: resource.cliCommand, verb: 'get', id })
+        handleError(err, { cliPath: resourceCliPath(resource), verb: 'get', id })
       }
     })
 }
@@ -301,7 +311,7 @@ const registerList = (parent: Command, resource: ResourceDef) => {
         })
       }
     } catch (err) {
-      handleError(err, { resourceName: resource.cliCommand, verb: 'list' })
+      handleError(err, { cliPath: resourceCliPath(resource), verb: 'list' })
     }
   })
 }
@@ -336,7 +346,7 @@ const registerDelete = (parent: Command, resource: ResourceDef) => {
         await manager.delete!(id)
         success(`${resource.displayName} '${id}' deleted`)
       } catch (err) {
-        handleError(err, { resourceName: resource.cliCommand, verb: 'delete', id })
+        handleError(err, { cliPath: resourceCliPath(resource), verb: 'delete', id })
       }
     })
 }
@@ -371,7 +381,7 @@ const registerExpire = (parent: Command, resource: ResourceDef) => {
         await manager.expire!(id)
         success(`${resource.displayName} '${id}' expired`)
       } catch (err) {
-        handleError(err, { resourceName: resource.cliCommand, verb: 'expire', id })
+        handleError(err, { cliPath: resourceCliPath(resource), verb: 'expire', id })
       }
     })
 }

--- a/src/resources/registry.ts
+++ b/src/resources/registry.ts
@@ -90,7 +90,7 @@ export const resources: ResourceDef[] = [
     listFlags: [
       {
         name: 'status',
-        type: 'string',
+        type: 'string[]',
         description: 'Filter by status (pending, succeeded, failed, rejected)',
       },
       {
@@ -320,3 +320,6 @@ export const resources: ResourceDef[] = [
     listFlags: [],
   },
 ]
+
+export const v1Resources = resources.filter((r) => r.sdkNamespace === 'v1')
+export const v2Resources = resources.filter((r) => r.sdkNamespace === 'v2')


### PR DESCRIPTION
## Contexto

Los recursos `transfers` y `accounts` usan la API v2, pero se accedían igual que los v1. Se agrega un subcomando `fintoc v2` para reflejar la estructura real de la API (e.g., `fintoc v2 transfers list`).

## Que hay de nuevo?

- [x] Subcomando `fintoc v2` que agrupa `transfers` y `accounts`
- [x] Prefijo `v2` propagado en mensajes de error, hints de uso y help
- [x] `getRootOpts` recorre parents dinámicamente (soporta nesting variable)
- [x] Flag `status` de transfers usa `string[]` (la API de pacioli para transfers acepta arrays); los demás recursos (incluyendo v2 accounts) mantienen `string` (solo aceptan un valor)

## Tests

- [x] Tests unitarios para factory, registry y errors

<sup>*Created with Claude Code `/create-pr` command*</sup>