### PR TITLE
[ONB-1827] Fix: doctor — stderr de npm filtrado y severidades incorrectas

### DIFF
--- a/src/commands/__tests__/doctor.test.ts
+++ b/src/commands/__tests__/doctor.test.ts
@@ -3,7 +3,7 @@ import { Command } from 'commander'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { resolveAuth, whoami } from '../../lib/auth.js'
 import { readConfig } from '../../lib/config.js'
-import { error, log, success, warn } from '../../lib/output.js'
+import { error, info, log, success, warn } from '../../lib/output.js'
 import { doctorCommand } from '../doctor.js'
 
 const { mockExecSync, mockExistsSync, mockStatSync } = vi.hoisted(() => ({
@@ -37,6 +37,7 @@ vi.mock('../../lib/output.js', () => ({
   success: vi.fn(),
   error: vi.fn(),
   warn: vi.fn(),
+  info: vi.fn(),
 }))
 
 vi.mock('../../lib/version.js', () => ({
@@ -80,12 +81,48 @@ describe('doctor command', () => {
       expect(success).toHaveBeenCalledWith(expect.stringContaining('Acme Corp'))
     })
 
-    test('reports JWS key as not configured', async () => {
+    test('reports JWS key as info, not error', async () => {
       const program = createProgram()
       await program.parseAsync(['doctor'], { from: 'user' })
 
-      expect(error).toHaveBeenCalledTimes(1)
-      expect(error).toHaveBeenCalledWith(expect.stringContaining('JWS private key'))
+      expect(error).not.toHaveBeenCalledWith(expect.stringContaining('JWS private key'))
+      expect(info).toHaveBeenCalledWith(
+        expect.stringContaining('JWS private key     not configured'),
+      )
+    })
+  })
+
+  describe('when npm version check fails', () => {
+    beforeEach(() => {
+      mockExecSync.mockImplementation(() => {
+        throw new Error('npm ERR! 404')
+      })
+      mockExistsSync.mockReturnValue(true)
+      mockStatSync.mockReturnValue({ mode: 0o100600 } as ReturnType<typeof mockStatSync>)
+      vi.mocked(resolveAuth).mockReturnValue({ secretKey: 'sk_test_abc123', source: 'config' })
+      vi.mocked(whoami).mockResolvedValue({
+        organizationName: 'Acme Corp',
+        mode: 'test',
+        apiVersion: '2023-03-15',
+      })
+    })
+
+    test('passes stdio pipe to suppress stderr', async () => {
+      const program = createProgram()
+      await program.parseAsync(['doctor'], { from: 'user' })
+
+      expect(mockExecSync).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ stdio: ['pipe', 'pipe', 'pipe'] }),
+      )
+    })
+
+    test('shows version without error', async () => {
+      const program = createProgram()
+      await program.parseAsync(['doctor'], { from: 'user' })
+
+      expect(success).toHaveBeenCalledWith(expect.stringContaining('CLI version'))
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('could not check for updates'))
     })
   })
 
@@ -148,19 +185,69 @@ describe('doctor command', () => {
   })
 
   describe('when config file is missing', () => {
-    beforeEach(() => {
-      mockExecSync.mockReturnValue('0.1.0\n')
-      mockExistsSync.mockReturnValue(false)
-      vi.mocked(resolveAuth).mockImplementation(() => {
-        throw new Error('No API key')
+    describe('when auth is resolved via env var', () => {
+      beforeEach(() => {
+        mockExecSync.mockReturnValue('0.1.0\n')
+        mockExistsSync.mockReturnValue(false)
+        vi.mocked(resolveAuth).mockReturnValue({
+          secretKey: 'sk_test_abc123',
+          source: 'env',
+        })
+        vi.mocked(whoami).mockResolvedValue({
+          organizationName: 'Acme Corp',
+          mode: 'test',
+          apiVersion: '2023-03-15',
+        })
+      })
+
+      test('reports config file as warning, not error', async () => {
+        const program = createProgram()
+        await program.parseAsync(['doctor'], { from: 'user' })
+
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('not found (using env)'))
+        expect(error).not.toHaveBeenCalledWith(expect.stringContaining('Config file'))
       })
     })
 
-    test('reports config file not found', async () => {
-      const program = createProgram()
-      await program.parseAsync(['doctor'], { from: 'user' })
+    describe('when auth is resolved via flag', () => {
+      beforeEach(() => {
+        mockExecSync.mockReturnValue('0.1.0\n')
+        mockExistsSync.mockReturnValue(false)
+        vi.mocked(resolveAuth).mockReturnValue({
+          secretKey: 'sk_test_abc123',
+          source: 'flag',
+        })
+        vi.mocked(whoami).mockResolvedValue({
+          organizationName: 'Acme Corp',
+          mode: 'test',
+          apiVersion: '2023-03-15',
+        })
+      })
 
-      expect(error).toHaveBeenCalledWith(expect.stringContaining('not found'))
+      test('reports config file as warning, not error', async () => {
+        const program = createProgram()
+        await program.parseAsync(['doctor'], { from: 'user' })
+
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('not found (using flag)'))
+        expect(error).not.toHaveBeenCalledWith(expect.stringContaining('Config file'))
+      })
+    })
+
+    describe('when no auth is available', () => {
+      beforeEach(() => {
+        mockExecSync.mockReturnValue('0.1.0\n')
+        mockExistsSync.mockReturnValue(false)
+        vi.mocked(resolveAuth).mockImplementation(() => {
+          throw new Error('No API key')
+        })
+      })
+
+      test('reports config file as error', async () => {
+        const program = createProgram()
+        await program.parseAsync(['doctor'], { from: 'user' })
+
+        expect(error).toHaveBeenCalledWith(expect.stringContaining('not found'))
+      })
     })
   })
 })

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -5,7 +5,7 @@ import { existsSync, statSync } from 'node:fs'
 import { maskKey, resolveAuth, whoami } from '../lib/auth.js'
 import { CONFIG_PATH, readConfig } from '../lib/config.js'
 import { API_HOST, NPM_PACKAGE_NAME } from '../lib/constants.js'
-import { error, log, success, warn } from '../lib/output.js'
+import { error, info, log, success, warn } from '../lib/output.js'
 import { getCliVersion } from '../lib/version.js'
 
 const checkCliVersion = () => {
@@ -14,6 +14,7 @@ const checkCliVersion = () => {
     const latest = execSync(`npm view ${NPM_PACKAGE_NAME} version`, {
       encoding: 'utf-8',
       timeout: 10_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
     }).trim()
 
     if (latest === currentVersion) {
@@ -27,9 +28,13 @@ const checkCliVersion = () => {
   }
 }
 
-const checkConfigFile = () => {
+const checkConfigFile = (authSource?: string) => {
   if (!existsSync(CONFIG_PATH)) {
-    error(`Config file         ${CONFIG_PATH} not found`)
+    if (authSource) {
+      warn(`Config file         ${CONFIG_PATH} not found (using ${authSource})`)
+    } else {
+      error(`Config file         ${CONFIG_PATH} not found`)
+    }
     return
   }
 
@@ -49,7 +54,7 @@ const checkApiKey = (options?: { apiKey?: string }) => {
   try {
     const auth = resolveAuth(options)
     success(`API key             ${maskKey(auth.secretKey)} (source: ${auth.source})`)
-    return auth.secretKey
+    return auth
   } catch {
     error('API key             not configured')
     log('                    Run `fintoc login` or set FINTOC_SECRET_KEY')
@@ -71,7 +76,7 @@ const checkConnectivity = async (secretKey: string) => {
 const checkJwsKey = () => {
   const config = readConfig()
   if (!config.jws_private_key) {
-    error('JWS private key     not configured (required for transfers create)')
+    info('JWS private key     not configured (only needed for transfers create)')
     return
   }
 
@@ -91,11 +96,12 @@ export const doctorCommand = (program: Command) => {
       const rootOpts = cmd.parent!.opts<{ apiKey?: string }>()
       log('')
       checkCliVersion()
-      checkConfigFile()
-      const secretKey = checkApiKey(rootOpts)
 
-      if (secretKey) {
-        await checkConnectivity(secretKey)
+      const auth = checkApiKey(rootOpts)
+      checkConfigFile(auth?.source)
+
+      if (auth) {
+        await checkConnectivity(auth.secretKey)
       } else {
         log('  ⏭ Connectivity     skipped (no API key)')
         log('  ⏭ Organization     skipped (no API key)')

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -16,6 +16,10 @@ export const warn = (message: string) => {
   console.error(`⚠ ${message}`)
 }
 
+export const info = (message: string) => {
+  console.log(`ℹ ${message}`)
+}
+
 // ANSI color helpers
 const green = (text: string) => `\x1B[32m${text}\x1B[0m`
 const yellow = (text: string) => `\x1B[33m${text}\x1B[0m`


### PR DESCRIPTION
## Contexto

`fintoc doctor` mostraba severidades incorrectas: stderr de npm se imprimía al terminal, JWS key aparecía como error siendo irrelevante para la mayoría, y config file mostraba error con auth válida vía env/flag.

## Que hay de nuevo?

- [x] Suprimir stderr de npm con `stdio: pipe`
- [x] JWS key no configurada → `ℹ` info en vez de `✘` error
- [x] Config file no encontrado → `⚠` warning cuando hay auth por otra fuente
- [x] Nuevo helper `info()` en `output.ts`

## Tests

- [x] Tests unitarios

Closes ONB-1827

<sup>*Created with Claude Code `/create-pr` command*</sup>