### PR TITLE
[ONB-1826] Fix: get/create full output y columnas de accounts

### DIFF
--- a/src/lib/__tests__/output.test.ts
+++ b/src/lib/__tests__/output.test.ts
@@ -82,6 +82,11 @@ describe('formatValue', () => {
     expect(result).toContain('\x1B[32m')
   })
 
+  test('colorizes keys ending with _status', () => {
+    const result = formatValue('payment_status', 'succeeded')
+    expect(result).toContain('\x1B[32m')
+  })
+
   test('formats Date as YYYY-MM-DD', () => {
     const result = formatValue('created_at', new Date('2026-04-22T12:00:00Z'))
     expect(result).toBe('2026-04-22')
@@ -139,6 +144,22 @@ describe('printTable', () => {
       expect(calls[1]).toContain('pi_123')
       expect(calls[2]).toContain('pi_456')
       expect(calls[4]).toContain('Showing 2 results')
+    })
+
+    test('resolves nested paths in columns', () => {
+      const calls: string[] = []
+      vi.spyOn(console, 'log').mockImplementation((msg: string) => {
+        calls.push(msg)
+      })
+
+      printTable({
+        columns: ['id', 'entity.holder_name'],
+        rows: [{ id: 'acc_1', entity: { holder_name: 'Acme Corp' } }],
+      })
+
+      expect(calls[0]).toContain('ENTITY_HOLDER_NAME')
+      expect(calls[0]).not.toContain('ENTITY.HOLDER_NAME')
+      expect(calls[1]).toContain('Acme Corp')
     })
 
     test('uses singular "result" for single row', () => {
@@ -220,6 +241,52 @@ describe('printDetail', () => {
 
       expect(calls).toHaveLength(2)
       expect(calls.every((c) => !c.includes('hidden'))).toBe(true)
+    })
+  })
+
+  describe('when columns contain nested paths', () => {
+    test('resolves nested values and uses full path as label', () => {
+      const calls: string[] = []
+      vi.spyOn(console, 'log').mockImplementation((msg: string) => {
+        calls.push(msg)
+      })
+
+      printDetail({ id: 'acc_1', entity: { holder_name: 'Acme Corp' } }, [
+        'id',
+        'entity.holder_name',
+      ])
+
+      expect(calls).toHaveLength(2)
+      expect(calls[1]).toContain('entity_holder_name')
+      expect(calls[1]).toContain('Acme Corp')
+    })
+
+    test('shows dash when nested path resolves to undefined', () => {
+      const calls: string[] = []
+      vi.spyOn(console, 'log').mockImplementation((msg: string) => {
+        calls.push(msg)
+      })
+
+      printDetail({ id: 'acc_1', entity: {} }, ['id', 'entity.holder_name'])
+
+      expect(calls).toHaveLength(2)
+      expect(calls[1]).toContain('entity_holder_name')
+      expect(calls[1]).toContain('—')
+    })
+  })
+
+  describe('when no columns are provided', () => {
+    test('shows all top-level keys', () => {
+      const calls: string[] = []
+      vi.spyOn(console, 'log').mockImplementation((msg: string) => {
+        calls.push(msg)
+      })
+
+      printDetail({ id: 'pi_123', amount: 10000, status: 'pending' })
+
+      expect(calls).toHaveLength(3)
+      expect(calls[0]).toContain('pi_123')
+      expect(calls[1]).toContain('10000')
     })
   })
 })

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -49,6 +49,20 @@ export const colorizeStatus = (status: string) => {
   return STATUS_COLORS[status as keyof typeof STATUS_COLORS](status)
 }
 
+const toLabel = (path: string) => path.replace(/\./g, '_')
+
+const getNestedValue = (obj: Record<string, unknown>, path: string): unknown => {
+  if (!path.includes('.')) {
+    return obj[path]
+  }
+  return path.split('.').reduce<unknown>((current, key) => {
+    if (current !== null && current !== undefined && typeof current === 'object') {
+      return (current as Record<string, unknown>)[key]
+    }
+    return undefined
+  }, obj)
+}
+
 // Strip ANSI codes for width calculation
 // eslint-disable-next-line no-control-regex
 const stripAnsi = (str: string) => str.replace(/\x1B\[[0-9;]*m/g, '')
@@ -63,7 +77,7 @@ export const formatValue = (key: string, value: unknown) => {
   if (value === null || value === undefined) {
     return dim('—')
   }
-  if (key === 'status') {
+  if (key === 'status' || key.endsWith('_status')) {
     return colorizeStatus(String(value))
   }
   if (value instanceof Date) {
@@ -89,10 +103,11 @@ export const printTable = ({ columns, rows, total }: TableOptions) => {
   }
 
   // Build formatted rows (with ANSI codes for display)
-  const formattedRows = rows.map((row) => columns.map((col) => formatValue(col, row[col])))
+  const formattedRows = rows.map((row) =>
+    columns.map((col) => formatValue(toLabel(col), getNestedValue(row, col))),
+  )
 
-  // Calculate column widths using stripped ANSI text
-  const headers = columns.map((col) => col.toUpperCase())
+  const headers = columns.map((col) => toLabel(col).toUpperCase())
   const widths = columns.map((col, i) => {
     const cellWidths = formattedRows.map((row) => stripAnsi(row[i]).length)
     return Math.max(headers[i].length, ...cellWidths)
@@ -133,14 +148,13 @@ export const printDetail = (data: Record<string, unknown>, columns?: string[]) =
     return
   }
 
-  const maxKeyLen = Math.max(...keys.map((k) => k.length))
+  const labels = keys.map((k) => toLabel(k))
+  const maxKeyLen = Math.max(...labels.map((l) => l.length))
 
-  for (const key of keys) {
-    if (!(key in data)) {
-      continue
-    }
-    const label = key.padEnd(maxKeyLen)
-    const value = formatValue(key, data[key])
-    log(`${label}  ${value}`)
+  for (let i = 0; i < keys.length; i++) {
+    const value = getNestedValue(data, keys[i])
+    const label = labels[i].padEnd(maxKeyLen)
+    const formatted = formatValue(labels[i], value)
+    log(`${label}  ${formatted}`)
   }
 }

--- a/src/resources/__tests__/factory.test.ts
+++ b/src/resources/__tests__/factory.test.ts
@@ -143,7 +143,7 @@ describe('factory: create command', () => {
       currency: 'CLP',
     })
     expect(success).toHaveBeenCalled()
-    expect(printDetail).toHaveBeenCalled()
+    expect(printDetail).toHaveBeenCalledWith({ id: 'pi_123', amount: 10000, currency: 'CLP' })
   })
 
   test('converts kebab-case flags to snake_case for SDK', async () => {
@@ -543,7 +543,7 @@ describe('factory: get command', () => {
     vi.restoreAllMocks()
   })
 
-  test('calls SDK get with ID', async () => {
+  test('calls SDK get with ID and shows full object', async () => {
     const mockResult = { serialize: () => ({ id: 'pi_123', amount: 10000 }) }
     mockManager.get.mockResolvedValue(mockResult)
 
@@ -551,7 +551,7 @@ describe('factory: get command', () => {
     await program.parseAsync(['payment_intents', 'get', 'pi_123'], { from: 'user' })
 
     expect(mockManager.get).toHaveBeenCalledWith('pi_123')
-    expect(printDetail).toHaveBeenCalled()
+    expect(printDetail).toHaveBeenCalledWith({ id: 'pi_123', amount: 10000 })
   })
 
   test('outputs JSON when --json flag is set', async () => {

--- a/src/resources/factory.ts
+++ b/src/resources/factory.ts
@@ -238,7 +238,7 @@ const registerCreate = (parent: Command, resource: ResourceDef) => {
       } else {
         success(`${resource.displayName} created`)
         log('')
-        printDetail(data, resource.priorityColumns)
+        printDetail(data)
       }
     } catch (err) {
       handleError(err, { cliPath: resourceCliPath(resource), verb: 'create' })
@@ -262,7 +262,7 @@ const registerGet = (parent: Command, resource: ResourceDef) => {
         if (rootOpts.json) {
           printJson(data)
         } else {
-          printDetail(data, resource.priorityColumns)
+          printDetail(data)
         }
       } catch (err) {
         handleError(err, { cliPath: resourceCliPath(resource), verb: 'get', id })

--- a/src/resources/registry.ts
+++ b/src/resources/registry.ts
@@ -112,7 +112,14 @@ export const resources: ResourceDef[] = [
     sdkMethod: 'accounts',
     sdkNamespace: 'v2',
     verbs: ['get', 'list'],
-    priorityColumns: ['id', 'name', 'type', 'currency', 'balance', 'status'],
+    priorityColumns: [
+      'id',
+      'entity.holder_name',
+      'currency',
+      'available_balance',
+      'status',
+      'refreshed_at',
+    ],
     listFlags: [{ name: 'type', type: 'string', description: 'Filter by account type' }],
   },
   {


### PR DESCRIPTION
## Contexto

`get` y `create` solo mostraban `priorityColumns`, perdiendo información. Las columnas de `accounts` no coincidían con el dashboard. Los nested dot paths usaban solo el último segmento como label (ej: `HOLDER_NAME`), lo que podía ser ambiguo.

## Que hay de nuevo?

- [x] Soporte para dot paths en output (`entity.holder_name`)
- [x] Labels de nested paths usan el path completo (`ENTITY_HOLDER_NAME` en vez de `HOLDER_NAME`)
- [x] `get` y `create` muestran todos los campos del objeto
- [x] Columnas de `accounts` actualizadas para coincidir con dashboard
- [x] Eliminado código muerto en `printDetail` (skip condition que nunca se ejecutaba)

## Tests

- [x] Tests unitarios para nested paths y output completo
- [x] Test para nested path que resuelve a `undefined` (muestra `—`)

<sup>*Created with Claude Code `/create-pr` command*</sup>