### PR TITLE
[ONB-1825] Fix: output sin color en non-TTY y errores JSON con --json

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -7,6 +7,7 @@ import { error, log, success, warn } from '../lib/output.js'
 const ALLOWED_KEYS: readonly string[] = [
   'secret_key',
   'jws_private_key',
+  'color',
 ] satisfies readonly (keyof FintocConfig)[]
 
 const isConfigKey = (key: string): key is keyof FintocConfig => ALLOWED_KEYS.includes(key)
@@ -61,7 +62,7 @@ export const configCommand = (program: Command) => {
 
   configCmd
     .command('set <key> <value>')
-    .description('Set a config value (allowed keys: secret_key, jws_private_key)')
+    .description('Set a config value (allowed keys: secret_key, jws_private_key, color)')
     .action((key: string, value: string) => {
       if (!isConfigKey(key)) {
         error(`Unknown config key: '${key}'`)
@@ -72,7 +73,17 @@ export const configCommand = (program: Command) => {
       }
 
       const config = readConfig()
-      config[key] = value
+
+      if (key === 'color') {
+        if (value !== 'true' && value !== 'false') {
+          error(`Invalid value for 'color': must be 'true' or 'false'`)
+          process.exit(1)
+        }
+        config[key] = value === 'true'
+      } else {
+        config[key] = value
+      }
+
       writeConfig(config)
 
       success(`Config updated: ${key}`)

--- a/src/lib/__tests__/errors.test.ts
+++ b/src/lib/__tests__/errors.test.ts
@@ -252,4 +252,78 @@ describe('handleError', () => {
       expect(exitSpy).toHaveBeenCalledWith(1)
     })
   })
+
+  describe('when json is true', () => {
+    let stderrSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+      stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      stderrSpy.mockRestore()
+    })
+
+    test('emits JSON for no-auth error', () => {
+      const err = new Error('No API key found')
+
+      expect(() => handleError(err, { json: true })).toThrow('process.exit')
+
+      const output = JSON.parse(stderrSpy.mock.calls[0][0] as string)
+      expect(output).toEqual({
+        error: { type: 'auth_error', message: 'No API key found' },
+      })
+    })
+
+    test('emits JSON for connectivity error', () => {
+      const err = createNetworkError('ECONNREFUSED')
+
+      expect(() => handleError(err, { json: true })).toThrow('process.exit')
+
+      const output = JSON.parse(stderrSpy.mock.calls[0][0] as string)
+      expect(output).toEqual({
+        error: { type: 'connectivity_error', message: 'Could not connect to api.fintoc.com' },
+      })
+    })
+
+    test('emits JSON for FintocError with structured fields', () => {
+      const err = createFintocError('InvalidRequestError', {
+        type: 'invalid_request_error',
+        code: 'missing_resource',
+        param: 'id',
+        message: 'No such payment_intent: pi_invalid',
+      })
+
+      expect(() => handleError(err, { json: true, id: 'pi_invalid' })).toThrow('process.exit')
+
+      const output = JSON.parse(stderrSpy.mock.calls[0][0] as string)
+      expect(output).toEqual({
+        error: {
+          type: 'invalid_request_error',
+          code: 'missing_resource',
+          message: 'No such payment_intent: pi_invalid',
+        },
+      })
+    })
+
+    test('emits JSON for unknown error', () => {
+      const err = new Error('Something broke')
+
+      expect(() => handleError(err, { json: true })).toThrow('process.exit')
+
+      const output = JSON.parse(stderrSpy.mock.calls[0][0] as string)
+      expect(output).toEqual({
+        error: { type: 'unknown_error', message: 'Something broke' },
+      })
+    })
+
+    test('emits JSON for non-Error value', () => {
+      expect(() => handleError(42, { json: true })).toThrow('process.exit')
+
+      const output = JSON.parse(stderrSpy.mock.calls[0][0] as string)
+      expect(output).toEqual({
+        error: { type: 'unknown_error', message: 'An unexpected error occurred' },
+      })
+    })
+  })
 })

--- a/src/lib/__tests__/output.test.ts
+++ b/src/lib/__tests__/output.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
-
+import { readConfig } from '../config.js'
 import {
+  _resetColorCache,
   colorizeStatus,
   error,
   formatValue,
@@ -9,8 +10,92 @@ import {
   printJson,
   printTable,
   success,
+  supportsColor,
   warn,
 } from '../output.js'
+
+vi.mock('../config.js', () => ({
+  readConfig: vi.fn(() => ({})),
+}))
+
+describe('supportsColor', () => {
+  const originalEnv = process.env
+
+  afterEach(() => {
+    _resetColorCache()
+    process.env = originalEnv
+  })
+
+  describe('when FORCE_COLOR is set', () => {
+    test('returns true for non-zero value', () => {
+      process.env = { ...originalEnv, FORCE_COLOR: '1' }
+      expect(supportsColor()).toBe(true)
+    })
+
+    test('returns false for FORCE_COLOR=0', () => {
+      process.env = { ...originalEnv, FORCE_COLOR: '0' }
+      expect(supportsColor()).toBe(false)
+    })
+  })
+
+  describe('when NO_COLOR is set', () => {
+    test('returns false', () => {
+      process.env = { ...originalEnv, NO_COLOR: '' }
+      expect(supportsColor()).toBe(false)
+    })
+
+    test('returns false even with a value', () => {
+      process.env = { ...originalEnv, NO_COLOR: '1' }
+      expect(supportsColor()).toBe(false)
+    })
+  })
+
+  describe('when config.color is set', () => {
+    test('returns true when color is true in config', () => {
+      const { FORCE_COLOR: _fc, NO_COLOR: _nc, ...envWithout } = originalEnv
+      process.env = envWithout
+      vi.mocked(readConfig).mockReturnValue({ color: true })
+      expect(supportsColor()).toBe(true)
+    })
+
+    test('returns false when color is false in config', () => {
+      const { FORCE_COLOR: _fc, NO_COLOR: _nc, ...envWithout } = originalEnv
+      process.env = envWithout
+      vi.mocked(readConfig).mockReturnValue({ color: false })
+      expect(supportsColor()).toBe(false)
+    })
+
+    test('env vars take precedence over config', () => {
+      process.env = { ...originalEnv, NO_COLOR: '' }
+      vi.mocked(readConfig).mockReturnValue({ color: true })
+      expect(supportsColor()).toBe(false)
+    })
+  })
+
+  describe('when neither FORCE_COLOR nor NO_COLOR nor config is set', () => {
+    test('returns based on stdout.isTTY', () => {
+      const { FORCE_COLOR: _fc, NO_COLOR: _nc, ...envWithout } = originalEnv
+      process.env = envWithout
+      vi.mocked(readConfig).mockReturnValue({})
+      // In test environment, stdout is not a TTY
+      expect(supportsColor()).toBe(!!process.stdout.isTTY)
+    })
+  })
+})
+
+describe('colorizeStatus without color', () => {
+  const originalEnv = process.env
+
+  afterEach(() => {
+    _resetColorCache()
+    process.env = originalEnv
+  })
+
+  test('returns plain text when NO_COLOR is set', () => {
+    process.env = { ...originalEnv, NO_COLOR: '' }
+    expect(colorizeStatus('succeeded')).toBe('succeeded')
+  })
+})
 
 describe('console wrappers', () => {
   afterEach(() => {
@@ -43,19 +128,29 @@ describe('console wrappers', () => {
 })
 
 describe('colorizeStatus', () => {
-  test('applies green to succeeded', () => {
+  const originalEnv = process.env
+
+  afterEach(() => {
+    _resetColorCache()
+    process.env = originalEnv
+  })
+
+  test('applies green to succeeded when color is enabled', () => {
+    process.env = { ...originalEnv, FORCE_COLOR: '1' }
     const result = colorizeStatus('succeeded')
     expect(result).toContain('succeeded')
     expect(result).toContain('\x1B[32m')
   })
 
-  test('applies yellow to pending', () => {
+  test('applies yellow to pending when color is enabled', () => {
+    process.env = { ...originalEnv, FORCE_COLOR: '1' }
     const result = colorizeStatus('pending')
     expect(result).toContain('pending')
     expect(result).toContain('\x1B[33m')
   })
 
-  test('applies red to failed', () => {
+  test('applies red to failed when color is enabled', () => {
+    process.env = { ...originalEnv, FORCE_COLOR: '1' }
     const result = colorizeStatus('failed')
     expect(result).toContain('failed')
     expect(result).toContain('\x1B[31m')
@@ -67,6 +162,13 @@ describe('colorizeStatus', () => {
 })
 
 describe('formatValue', () => {
+  const originalEnv = process.env
+
+  afterEach(() => {
+    _resetColorCache()
+    process.env = originalEnv
+  })
+
   test('formats null as dim dash', () => {
     const result = formatValue('id', null)
     expect(result).toContain('—')
@@ -77,12 +179,14 @@ describe('formatValue', () => {
     expect(result).toContain('—')
   })
 
-  test('colorizes status values', () => {
+  test('colorizes status values when color is enabled', () => {
+    process.env = { ...originalEnv, FORCE_COLOR: '1' }
     const result = formatValue('status', 'succeeded')
     expect(result).toContain('\x1B[32m')
   })
 
-  test('colorizes keys ending with _status', () => {
+  test('colorizes keys ending with _status when color is enabled', () => {
+    process.env = { ...originalEnv, FORCE_COLOR: '1' }
     const result = formatValue('payment_status', 'succeeded')
     expect(result).toContain('\x1B[32m')
   })

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -5,6 +5,7 @@ type ErrorContext = {
   cliPath?: string
   verb?: string
   id?: string
+  json?: boolean
 }
 
 // Parsed fields from a FintocError message.
@@ -93,9 +94,17 @@ const printNextSteps = (steps: string[]) => {
   steps.forEach((step) => log(`  ${step}`))
 }
 
+const exitJsonError = (fields: { type: string; code?: string; message: string }): never => {
+  console.error(JSON.stringify({ error: fields }))
+  return process.exit(1)
+}
+
 export const handleError = (err: unknown, context?: ErrorContext): never => {
   // No API key configured
   if (isNoAuthError(err)) {
+    if (context?.json) {
+      return exitJsonError({ type: 'auth_error', message: 'No API key found' })
+    }
     error('No API key found. To authenticate:')
     printNextSteps([
       'Run:   fintoc login',
@@ -109,6 +118,12 @@ export const handleError = (err: unknown, context?: ErrorContext): never => {
 
   // Network / connectivity failure
   if (isConnectivityError(err)) {
+    if (context?.json) {
+      return exitJsonError({
+        type: 'connectivity_error',
+        message: `Could not connect to ${API_HOST}`,
+      })
+    }
     error(`Could not connect to ${API_HOST}`)
     printNextSteps(['Check your internet connection, or run: fintoc doctor'])
     return process.exit(1)
@@ -118,6 +133,14 @@ export const handleError = (err: unknown, context?: ErrorContext): never => {
   const fields = parseFintocError(err)
 
   if (fields) {
+    if (context?.json) {
+      return exitJsonError({
+        type: fields.type,
+        code: fields.code,
+        message: fields.message ?? (err as Error).message,
+      })
+    }
+
     // JWS private key missing (for transfers)
     if (fields.code === 'missing_jws_signature_header') {
       error('JWS private key required for transfer operations')
@@ -156,6 +179,9 @@ export const handleError = (err: unknown, context?: ErrorContext): never => {
 
   // Unknown / unexpected errors
   const message = err instanceof Error ? err.message : 'An unexpected error occurred'
+  if (context?.json) {
+    return exitJsonError({ type: 'unknown_error', message })
+  }
   error(message)
   return process.exit(1)
 }

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import { readConfig } from './config.js'
 
 export const log = (message: string) => {
   console.log(message)
@@ -20,11 +21,40 @@ export const info = (message: string) => {
   console.log(`ℹ ${message}`)
 }
 
-// ANSI color helpers
-const green = (text: string) => `\x1B[32m${text}\x1B[0m`
-const yellow = (text: string) => `\x1B[33m${text}\x1B[0m`
-const red = (text: string) => `\x1B[31m${text}\x1B[0m`
-const dim = (text: string) => `\x1B[2m${text}\x1B[0m`
+// Color support detection: FORCE_COLOR > NO_COLOR > config.color > TTY check
+let _colorEnabled: boolean | undefined
+
+export const supportsColor = () => {
+  if (_colorEnabled !== undefined) {
+    return _colorEnabled
+  }
+
+  if ('FORCE_COLOR' in process.env) {
+    _colorEnabled = process.env.FORCE_COLOR !== '0'
+  } else if ('NO_COLOR' in process.env) {
+    _colorEnabled = false
+  } else {
+    const config = (() => {
+      try {
+        return readConfig()
+      } catch {
+        return {}
+      }
+    })()
+    _colorEnabled = config.color !== undefined ? config.color : !!process.stdout.isTTY
+  }
+
+  return _colorEnabled
+}
+
+export const _resetColorCache = () => {
+  _colorEnabled = undefined
+}
+
+const green = (text: string) => (supportsColor() ? `\x1B[32m${text}\x1B[0m` : text)
+const yellow = (text: string) => (supportsColor() ? `\x1B[33m${text}\x1B[0m` : text)
+const red = (text: string) => (supportsColor() ? `\x1B[31m${text}\x1B[0m` : text)
+const dim = (text: string) => (supportsColor() ? `\x1B[2m${text}\x1B[0m` : text)
 
 const STATUS_COLORS = {
   succeeded: green,

--- a/src/resources/factory.ts
+++ b/src/resources/factory.ts
@@ -241,7 +241,7 @@ const registerCreate = (parent: Command, resource: ResourceDef) => {
         printDetail(data)
       }
     } catch (err) {
-      handleError(err, { cliPath: resourceCliPath(resource), verb: 'create' })
+      handleError(err, { cliPath: resourceCliPath(resource), verb: 'create', json: rootOpts.json })
     }
   })
 }
@@ -251,8 +251,8 @@ const registerGet = (parent: Command, resource: ResourceDef) => {
     .command('get <id>')
     .description(`Get a ${resource.displayName} by ID`)
     .action(async (id: string, _opts: unknown, actionCmd: Command) => {
+      const rootOpts = getRootOpts(actionCmd)
       try {
-        const rootOpts = getRootOpts(actionCmd)
         const client = resolveClient(rootOpts, resource)
         const manager = getManager(client, resource)
 
@@ -265,7 +265,12 @@ const registerGet = (parent: Command, resource: ResourceDef) => {
           printDetail(data)
         }
       } catch (err) {
-        handleError(err, { cliPath: resourceCliPath(resource), verb: 'get', id })
+        handleError(err, {
+          cliPath: resourceCliPath(resource),
+          verb: 'get',
+          id,
+          json: rootOpts.json,
+        })
       }
     })
 }
@@ -311,7 +316,7 @@ const registerList = (parent: Command, resource: ResourceDef) => {
         })
       }
     } catch (err) {
-      handleError(err, { cliPath: resourceCliPath(resource), verb: 'list' })
+      handleError(err, { cliPath: resourceCliPath(resource), verb: 'list', json: rootOpts.json })
     }
   })
 }
@@ -346,7 +351,12 @@ const registerDelete = (parent: Command, resource: ResourceDef) => {
         await manager.delete!(id)
         success(`${resource.displayName} '${id}' deleted`)
       } catch (err) {
-        handleError(err, { cliPath: resourceCliPath(resource), verb: 'delete', id })
+        handleError(err, {
+          cliPath: resourceCliPath(resource),
+          verb: 'delete',
+          id,
+          json: rootOpts.json,
+        })
       }
     })
 }
@@ -381,7 +391,12 @@ const registerExpire = (parent: Command, resource: ResourceDef) => {
         await manager.expire!(id)
         success(`${resource.displayName} '${id}' expired`)
       } catch (err) {
-        handleError(err, { cliPath: resourceCliPath(resource), verb: 'expire', id })
+        handleError(err, {
+          cliPath: resourceCliPath(resource),
+          verb: 'expire',
+          id,
+          json: rootOpts.json,
+        })
       }
     })
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export type FintocConfig = {
   secret_key?: string
   jws_private_key?: string
+  color?: boolean
 }
 
 export type Verb = 'create' | 'get' | 'list' | 'delete' | 'expire'


### PR DESCRIPTION
## Contexto

La CLI emitía ANSI escape codes siempre, incluso en pipes. Además, con `--json` los errores salían en formato humano, rompiendo el parsing para agentes.

## Que hay de nuevo?

- [x] `supportsColor()` con precedencia `FORCE_COLOR` > `NO_COLOR` > `config.color` > TTY, con cache lazy
- [x] `handleError` emite JSON estructurado a stderr cuando `--json` está activo
- [x] Factory pasa `json` al contexto de error en todos los verbos
- [x] `config set color true/false` para override manual

## Tests

- [x] Tests unitarios para `supportsColor` y errores JSON

<sup>*Created with Claude Code `/create-pr` command*</sup>