### PR TITLE
[ONB-1829] Fix: validación local de tipos en flags y API key vacío

### DIFF
--- a/src/commands/__tests__/config.test.ts
+++ b/src/commands/__tests__/config.test.ts
@@ -8,7 +8,7 @@ import { configCommand } from '../config.js'
 vi.mock('../../lib/auth.js', () => ({
   resolveAuth: vi.fn(),
   whoami: vi.fn(),
-  maskKey: vi.fn((k: string) => `${k.slice(0, 8)}····`),
+  maskKey: vi.fn(() => 'sk_test_····'),
 }))
 
 vi.mock('../../lib/config.js', () => ({
@@ -36,49 +36,55 @@ describe('config command', () => {
     vi.clearAllMocks()
   })
 
-  test('shows full config when authenticated', async () => {
-    vi.mocked(resolveAuth).mockReturnValue({
-      secretKey: 'sk_test_abc123',
-      source: 'config',
-    })
-    vi.mocked(whoami).mockResolvedValue({
-      organizationName: 'Acme Corp',
-      mode: 'test',
-      apiVersion: '2023-03-15',
-    })
+  describe('when authenticated', () => {
+    test('shows full config', async () => {
+      vi.mocked(resolveAuth).mockReturnValue({
+        secretKey: 'sk_test_abc123',
+        source: 'config',
+      })
+      vi.mocked(whoami).mockResolvedValue({
+        organizationName: 'Acme Corp',
+        mode: 'test',
+        apiVersion: '2023-03-15',
+      })
 
-    const program = createProgram()
-    await program.parseAsync(['config'], { from: 'user' })
+      const program = createProgram()
+      await program.parseAsync(['config'], { from: 'user' })
 
-    expect(log).toHaveBeenCalledWith(expect.stringContaining('Acme Corp'))
-    expect(log).toHaveBeenCalledWith(expect.stringContaining('test'))
-    expect(log).toHaveBeenCalledWith(expect.stringContaining('config file'))
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('Acme Corp'))
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('test'))
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('config file'))
+    })
   })
 
-  test('shows not authenticated when no key', async () => {
-    vi.mocked(resolveAuth).mockImplementation(() => {
-      throw new Error('No API key found')
+  describe('when not authenticated', () => {
+    test('shows not authenticated message', async () => {
+      vi.mocked(resolveAuth).mockImplementation(() => {
+        throw new Error('No API key found')
+      })
+
+      const program = createProgram()
+      await program.parseAsync(['config'], { from: 'user' })
+
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('Not authenticated'))
     })
-
-    const program = createProgram()
-    await program.parseAsync(['config'], { from: 'user' })
-
-    expect(log).toHaveBeenCalledWith(expect.stringContaining('Not authenticated'))
   })
 
-  test('degrades gracefully when API is unreachable', async () => {
-    vi.mocked(resolveAuth).mockReturnValue({
-      secretKey: 'sk_test_abc123',
-      source: 'env',
+  describe('when API is unreachable', () => {
+    test('degrades gracefully', async () => {
+      vi.mocked(resolveAuth).mockReturnValue({
+        secretKey: 'sk_test_abc123',
+        source: 'env',
+      })
+      vi.mocked(whoami).mockRejectedValue(new Error('Network error'))
+
+      const program = createProgram()
+      await program.parseAsync(['config'], { from: 'user' })
+
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('Unable to reach Fintoc API'))
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('(unknown)'))
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('env var'))
     })
-    vi.mocked(whoami).mockRejectedValue(new Error('Network error'))
-
-    const program = createProgram()
-    await program.parseAsync(['config'], { from: 'user' })
-
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Unable to reach Fintoc API'))
-    expect(log).toHaveBeenCalledWith(expect.stringContaining('(unknown)'))
-    expect(log).toHaveBeenCalledWith(expect.stringContaining('env var'))
   })
 })
 
@@ -87,63 +93,69 @@ describe('config set command', () => {
     vi.clearAllMocks()
   })
 
-  test('sets jws_private_key in config', async () => {
-    vi.mocked(readConfig).mockReturnValue({ secret_key: 'sk_test_abc123' })
+  describe('when setting valid keys', () => {
+    test('sets jws_private_key in config', async () => {
+      vi.mocked(readConfig).mockReturnValue({ secret_key: 'sk_test_abc123' })
 
-    const program = createProgram()
-    await program.parseAsync(['config', 'set', 'jws_private_key', '/path/to/key.pem'], {
-      from: 'user',
+      const program = createProgram()
+      await program.parseAsync(['config', 'set', 'jws_private_key', '/path/to/key.pem'], {
+        from: 'user',
+      })
+
+      expect(writeConfig).toHaveBeenCalledWith({
+        secret_key: 'sk_test_abc123',
+        jws_private_key: '/path/to/key.pem',
+      })
+      expect(success).toHaveBeenCalledWith('Config updated: jws_private_key')
     })
 
-    expect(writeConfig).toHaveBeenCalledWith({
-      secret_key: 'sk_test_abc123',
-      jws_private_key: '/path/to/key.pem',
+    test('sets secret_key in config', async () => {
+      vi.mocked(readConfig).mockReturnValue({})
+
+      const program = createProgram()
+      await program.parseAsync(['config', 'set', 'secret_key', 'sk_test_newkey'], {
+        from: 'user',
+      })
+
+      expect(writeConfig).toHaveBeenCalledWith({ secret_key: 'sk_test_newkey' })
+      expect(success).toHaveBeenCalledWith('Config updated: secret_key')
     })
-    expect(success).toHaveBeenCalledWith('Config updated: jws_private_key')
+
+    test('preserves existing config values when setting a new key', async () => {
+      vi.mocked(readConfig).mockReturnValue({
+        secret_key: 'sk_test_existing',
+        jws_private_key: '/old/path.pem',
+      })
+
+      const program = createProgram()
+      await program.parseAsync(['config', 'set', 'jws_private_key', '/new/path.pem'], {
+        from: 'user',
+      })
+
+      expect(writeConfig).toHaveBeenCalledWith({
+        secret_key: 'sk_test_existing',
+        jws_private_key: '/new/path.pem',
+      })
+    })
   })
 
-  test('sets secret_key in config', async () => {
-    vi.mocked(readConfig).mockReturnValue({})
+  describe('when key is unknown', () => {
+    test('rejects and does not write', async () => {
+      const mockExit = vi.spyOn(process, 'exit').mockImplementation((code) => {
+        throw new Error(`exit ${code}`)
+      })
 
-    const program = createProgram()
-    await program.parseAsync(['config', 'set', 'secret_key', 'sk_test_newkey'], {
-      from: 'user',
-    })
+      const program = createProgram()
+      await expect(
+        program.parseAsync(['config', 'set', 'unknown_key', 'value'], { from: 'user' }),
+      ).rejects.toThrow('exit 1')
 
-    expect(writeConfig).toHaveBeenCalledWith({ secret_key: 'sk_test_newkey' })
-    expect(success).toHaveBeenCalledWith('Config updated: secret_key')
-  })
+      expect(error).toHaveBeenCalledWith(
+        expect.stringContaining("Unknown config key: 'unknown_key'"),
+      )
+      expect(writeConfig).not.toHaveBeenCalled()
 
-  test('rejects unknown config keys', async () => {
-    const mockExit = vi.spyOn(process, 'exit').mockImplementation((code) => {
-      throw new Error(`exit ${code}`)
-    })
-
-    const program = createProgram()
-    await expect(
-      program.parseAsync(['config', 'set', 'unknown_key', 'value'], { from: 'user' }),
-    ).rejects.toThrow('exit 1')
-
-    expect(error).toHaveBeenCalledWith(expect.stringContaining("Unknown config key: 'unknown_key'"))
-    expect(writeConfig).not.toHaveBeenCalled()
-
-    mockExit.mockRestore()
-  })
-
-  test('preserves existing config values when setting a new key', async () => {
-    vi.mocked(readConfig).mockReturnValue({
-      secret_key: 'sk_test_existing',
-      jws_private_key: '/old/path.pem',
-    })
-
-    const program = createProgram()
-    await program.parseAsync(['config', 'set', 'jws_private_key', '/new/path.pem'], {
-      from: 'user',
-    })
-
-    expect(writeConfig).toHaveBeenCalledWith({
-      secret_key: 'sk_test_existing',
-      jws_private_key: '/new/path.pem',
+      mockExit.mockRestore()
     })
   })
 })

--- a/src/commands/__tests__/doctor.test.ts
+++ b/src/commands/__tests__/doctor.test.ts
@@ -1,4 +1,5 @@
-import type { ExecSyncOptions } from 'node:child_process'
+import { execSync } from 'node:child_process'
+import { existsSync, statSync } from 'node:fs'
 import { Command } from 'commander'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { resolveAuth, whoami } from '../../lib/auth.js'
@@ -6,25 +7,19 @@ import { readConfig } from '../../lib/config.js'
 import { error, info, log, success, warn } from '../../lib/output.js'
 import { doctorCommand } from '../doctor.js'
 
-const { mockExecSync, mockExistsSync, mockStatSync } = vi.hoisted(() => ({
-  mockExecSync: vi.fn<(cmd: string, opts?: ExecSyncOptions) => string>(),
-  mockExistsSync: vi.fn<(path: string) => boolean>(),
-  mockStatSync: vi.fn(),
-}))
-
 vi.mock('node:child_process', () => ({
-  execSync: mockExecSync,
+  execSync: vi.fn(),
 }))
 
 vi.mock('node:fs', () => ({
-  existsSync: mockExistsSync,
-  statSync: mockStatSync,
+  existsSync: vi.fn(),
+  statSync: vi.fn(),
 }))
 
 vi.mock('../../lib/auth.js', () => ({
   resolveAuth: vi.fn(),
   whoami: vi.fn(),
-  maskKey: vi.fn((k: string) => `${k.slice(0, 8)}····`),
+  maskKey: vi.fn(() => 'sk_test_····'),
 }))
 
 vi.mock('../../lib/config.js', () => ({
@@ -52,24 +47,22 @@ const createProgram = () => {
 }
 
 describe('doctor command', () => {
+  // Default: all checks pass
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(execSync).mockReturnValue('0.1.0\n')
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(statSync).mockReturnValue({ mode: 0o100600 } as ReturnType<typeof statSync>)
     vi.mocked(readConfig).mockReturnValue({})
+    vi.mocked(resolveAuth).mockReturnValue({ secretKey: 'sk_test_abc123', source: 'config' })
+    vi.mocked(whoami).mockResolvedValue({
+      organizationName: 'Acme Corp',
+      mode: 'test',
+      apiVersion: '2023-03-15',
+    })
   })
 
   describe('when all checks pass', () => {
-    beforeEach(() => {
-      mockExecSync.mockReturnValue('0.1.0\n')
-      mockExistsSync.mockReturnValue(true)
-      mockStatSync.mockReturnValue({ mode: 0o100600 } as ReturnType<typeof mockStatSync>)
-      vi.mocked(resolveAuth).mockReturnValue({ secretKey: 'sk_test_abc123', source: 'config' })
-      vi.mocked(whoami).mockResolvedValue({
-        organizationName: 'Acme Corp',
-        mode: 'test',
-        apiVersion: '2023-03-15',
-      })
-    })
-
     test('reports success for CLI version, config, API key, and connectivity', async () => {
       const program = createProgram()
       await program.parseAsync(['doctor'], { from: 'user' })
@@ -94,16 +87,8 @@ describe('doctor command', () => {
 
   describe('when npm version check fails', () => {
     beforeEach(() => {
-      mockExecSync.mockImplementation(() => {
+      vi.mocked(execSync).mockImplementation(() => {
         throw new Error('npm ERR! 404')
-      })
-      mockExistsSync.mockReturnValue(true)
-      mockStatSync.mockReturnValue({ mode: 0o100600 } as ReturnType<typeof mockStatSync>)
-      vi.mocked(resolveAuth).mockReturnValue({ secretKey: 'sk_test_abc123', source: 'config' })
-      vi.mocked(whoami).mockResolvedValue({
-        organizationName: 'Acme Corp',
-        mode: 'test',
-        apiVersion: '2023-03-15',
       })
     })
 
@@ -111,7 +96,7 @@ describe('doctor command', () => {
       const program = createProgram()
       await program.parseAsync(['doctor'], { from: 'user' })
 
-      expect(mockExecSync).toHaveBeenCalledWith(
+      expect(execSync).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({ stdio: ['pipe', 'pipe', 'pipe'] }),
       )
@@ -128,9 +113,6 @@ describe('doctor command', () => {
 
   describe('when API key is missing', () => {
     beforeEach(() => {
-      mockExecSync.mockReturnValue('0.1.0\n')
-      mockExistsSync.mockReturnValue(true)
-      mockStatSync.mockReturnValue({ mode: 0o100600 } as ReturnType<typeof mockStatSync>)
       vi.mocked(resolveAuth).mockImplementation(() => {
         throw new Error('No API key')
       })
@@ -148,10 +130,6 @@ describe('doctor command', () => {
 
   describe('when API is unreachable', () => {
     beforeEach(() => {
-      mockExecSync.mockReturnValue('0.1.0\n')
-      mockExistsSync.mockReturnValue(true)
-      mockStatSync.mockReturnValue({ mode: 0o100600 } as ReturnType<typeof mockStatSync>)
-      vi.mocked(resolveAuth).mockReturnValue({ secretKey: 'sk_test_abc123', source: 'config' })
       vi.mocked(whoami).mockRejectedValue(new Error('Network error'))
     })
 
@@ -165,15 +143,7 @@ describe('doctor command', () => {
 
   describe('when CLI version is outdated', () => {
     beforeEach(() => {
-      mockExecSync.mockReturnValue('0.2.0\n')
-      mockExistsSync.mockReturnValue(true)
-      mockStatSync.mockReturnValue({ mode: 0o100600 } as ReturnType<typeof mockStatSync>)
-      vi.mocked(resolveAuth).mockReturnValue({ secretKey: 'sk_test_abc123', source: 'config' })
-      vi.mocked(whoami).mockResolvedValue({
-        organizationName: 'Acme Corp',
-        mode: 'test',
-        apiVersion: '2023-03-15',
-      })
+      vi.mocked(execSync).mockReturnValue('0.2.0\n')
     })
 
     test('warns about newer version', async () => {
@@ -185,18 +155,15 @@ describe('doctor command', () => {
   })
 
   describe('when config file is missing', () => {
+    beforeEach(() => {
+      vi.mocked(existsSync).mockReturnValue(false)
+    })
+
     describe('when auth is resolved via env var', () => {
       beforeEach(() => {
-        mockExecSync.mockReturnValue('0.1.0\n')
-        mockExistsSync.mockReturnValue(false)
         vi.mocked(resolveAuth).mockReturnValue({
           secretKey: 'sk_test_abc123',
           source: 'env',
-        })
-        vi.mocked(whoami).mockResolvedValue({
-          organizationName: 'Acme Corp',
-          mode: 'test',
-          apiVersion: '2023-03-15',
         })
       })
 
@@ -211,16 +178,9 @@ describe('doctor command', () => {
 
     describe('when auth is resolved via flag', () => {
       beforeEach(() => {
-        mockExecSync.mockReturnValue('0.1.0\n')
-        mockExistsSync.mockReturnValue(false)
         vi.mocked(resolveAuth).mockReturnValue({
           secretKey: 'sk_test_abc123',
           source: 'flag',
-        })
-        vi.mocked(whoami).mockResolvedValue({
-          organizationName: 'Acme Corp',
-          mode: 'test',
-          apiVersion: '2023-03-15',
         })
       })
 
@@ -235,8 +195,6 @@ describe('doctor command', () => {
 
     describe('when no auth is available', () => {
       beforeEach(() => {
-        mockExecSync.mockReturnValue('0.1.0\n')
-        mockExistsSync.mockReturnValue(false)
         vi.mocked(resolveAuth).mockImplementation(() => {
           throw new Error('No API key')
         })

--- a/src/commands/__tests__/open.test.ts
+++ b/src/commands/__tests__/open.test.ts
@@ -1,3 +1,4 @@
+import { exec } from 'node:child_process'
 import { Command } from 'commander'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { error, success } from '../../lib/output.js'
@@ -20,20 +21,28 @@ const createProgram = () => {
 }
 
 describe('open command', () => {
+  let originalPlatform: string
+
   beforeEach(() => {
     vi.clearAllMocks()
+    originalPlatform = process.platform
+    vi.mocked(exec).mockImplementation((_cmd, callback) => {
+      ;(callback as (err: Error | null) => void)(null)
+      return undefined as never
+    })
   })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform })
+  })
+
+  const setPlatform = (value: string) => {
+    Object.defineProperty(process, 'platform', { value })
+  }
 
   describe('open dashboard', () => {
     test('opens dashboard URL in browser on macOS', async () => {
-      const { exec } = await import('node:child_process')
-      const originalPlatform = process.platform
-      Object.defineProperty(process, 'platform', { value: 'darwin' })
-
-      vi.mocked(exec).mockImplementation((_cmd, callback) => {
-        ;(callback as (err: Error | null) => void)(null)
-        return undefined as never
-      })
+      setPlatform('darwin')
 
       const program = createProgram()
       await program.parseAsync(['open', 'dashboard'], { from: 'user' })
@@ -43,19 +52,10 @@ describe('open command', () => {
         expect.any(Function),
       )
       expect(success).toHaveBeenCalledWith(expect.stringContaining('https://dashboard.fintoc.com/'))
-
-      Object.defineProperty(process, 'platform', { value: originalPlatform })
     })
 
     test('uses xdg-open on Linux', async () => {
-      const { exec } = await import('node:child_process')
-      const originalPlatform = process.platform
-      Object.defineProperty(process, 'platform', { value: 'linux' })
-
-      vi.mocked(exec).mockImplementation((_cmd, callback) => {
-        ;(callback as (err: Error | null) => void)(null)
-        return undefined as never
-      })
+      setPlatform('linux')
 
       const program = createProgram()
       await program.parseAsync(['open', 'dashboard'], { from: 'user' })
@@ -64,19 +64,10 @@ describe('open command', () => {
         'xdg-open "https://dashboard.fintoc.com/"',
         expect.any(Function),
       )
-
-      Object.defineProperty(process, 'platform', { value: originalPlatform })
     })
 
     test('uses start on Windows', async () => {
-      const { exec } = await import('node:child_process')
-      const originalPlatform = process.platform
-      Object.defineProperty(process, 'platform', { value: 'win32' })
-
-      vi.mocked(exec).mockImplementation((_cmd, callback) => {
-        ;(callback as (err: Error | null) => void)(null)
-        return undefined as never
-      })
+      setPlatform('win32')
 
       const program = createProgram()
       await program.parseAsync(['open', 'dashboard'], { from: 'user' })
@@ -85,14 +76,10 @@ describe('open command', () => {
         'start "" "https://dashboard.fintoc.com/"',
         expect.any(Function),
       )
-
-      Object.defineProperty(process, 'platform', { value: originalPlatform })
     })
 
     test('logs error when browser fails to open', async () => {
-      const { exec } = await import('node:child_process')
-      const originalPlatform = process.platform
-      Object.defineProperty(process, 'platform', { value: 'darwin' })
+      setPlatform('darwin')
 
       vi.mocked(exec).mockImplementation((_cmd, callback) => {
         ;(callback as (err: Error | null) => void)(new Error('spawn open ENOENT'))
@@ -104,14 +91,10 @@ describe('open command', () => {
 
       expect(error).toHaveBeenCalledWith(expect.stringContaining('Failed to open browser'))
       expect(success).not.toHaveBeenCalled()
-
-      Object.defineProperty(process, 'platform', { value: originalPlatform })
     })
 
     test('shows friendly error on unsupported platform', async () => {
-      const { exec } = await import('node:child_process')
-      const originalPlatform = process.platform
-      Object.defineProperty(process, 'platform', { value: 'freebsd' })
+      setPlatform('freebsd')
 
       const program = createProgram()
       await program.parseAsync(['open', 'dashboard'], { from: 'user' })
@@ -119,8 +102,6 @@ describe('open command', () => {
       expect(exec).not.toHaveBeenCalled()
       expect(error).toHaveBeenCalledWith(expect.stringContaining('Unsupported platform'))
       expect(success).not.toHaveBeenCalled()
-
-      Object.defineProperty(process, 'platform', { value: originalPlatform })
     })
   })
 })

--- a/src/commands/__tests__/open.test.ts
+++ b/src/commands/__tests__/open.test.ts
@@ -1,6 +1,6 @@
 import { exec } from 'node:child_process'
 import { Command } from 'commander'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { error, success } from '../../lib/output.js'
 import { openCommand } from '../open.js'
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -4,7 +4,12 @@ import { existsSync, statSync } from 'node:fs'
 
 import { maskKey, resolveAuth, whoami } from '../lib/auth.js'
 import { CONFIG_PATH, readConfig } from '../lib/config.js'
-import { API_HOST, NPM_PACKAGE_NAME } from '../lib/constants.js'
+import {
+  API_HOST,
+  CONFIG_FILE_PERMISSIONS,
+  NPM_CHECK_TIMEOUT_MS,
+  NPM_PACKAGE_NAME,
+} from '../lib/constants.js'
 import { error, info, log, success, warn } from '../lib/output.js'
 import { getCliVersion } from '../lib/version.js'
 
@@ -13,7 +18,7 @@ const checkCliVersion = () => {
   try {
     const latest = execSync(`npm view ${NPM_PACKAGE_NAME} version`, {
       encoding: 'utf-8',
-      timeout: 10_000,
+      timeout: NPM_CHECK_TIMEOUT_MS,
       stdio: ['pipe', 'pipe', 'pipe'],
     }).trim()
 
@@ -40,7 +45,7 @@ const checkConfigFile = (authSource?: string) => {
 
   const stats = statSync(CONFIG_PATH)
   const mode = stats.mode & 0o777
-  if (mode !== 0o600) {
+  if (mode !== CONFIG_FILE_PERMISSIONS) {
     warn(
       `Config file         ${CONFIG_PATH} found (permissions: ${mode.toString(8)}, expected: 600)`,
     )

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -59,6 +59,20 @@ describe('resolveAuth', () => {
     expect(() => resolveAuth({ apiKey: '   ' })).toThrow('API key is empty')
   })
 
+  test('throws when FINTOC_SECRET_KEY is empty string', () => {
+    process.env.FINTOC_SECRET_KEY = ''
+    vi.mocked(readConfig).mockReturnValue({ secret_key: 'sk_test_config' })
+
+    expect(() => resolveAuth()).toThrow('FINTOC_SECRET_KEY is set but empty')
+  })
+
+  test('throws when FINTOC_SECRET_KEY is only whitespace', () => {
+    process.env.FINTOC_SECRET_KEY = '   '
+    vi.mocked(readConfig).mockReturnValue({ secret_key: 'sk_test_config' })
+
+    expect(() => resolveAuth()).toThrow('FINTOC_SECRET_KEY is set but empty')
+  })
+
   test('throws when no key found', () => {
     vi.mocked(readConfig).mockReturnValue({})
 

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -45,6 +45,20 @@ describe('resolveAuth', () => {
     expect(result).toEqual({ secretKey: 'sk_test_config', source: 'config' })
   })
 
+  test('throws when --api-key is empty string', () => {
+    process.env.FINTOC_SECRET_KEY = 'sk_test_env'
+    vi.mocked(readConfig).mockReturnValue({ secret_key: 'sk_test_config' })
+
+    expect(() => resolveAuth({ apiKey: '' })).toThrow('API key is empty')
+  })
+
+  test('throws when --api-key is only whitespace', () => {
+    process.env.FINTOC_SECRET_KEY = 'sk_test_env'
+    vi.mocked(readConfig).mockReturnValue({ secret_key: 'sk_test_config' })
+
+    expect(() => resolveAuth({ apiKey: '   ' })).toThrow('API key is empty')
+  })
+
   test('throws when no key found', () => {
     vi.mocked(readConfig).mockReturnValue({})
 

--- a/src/lib/__tests__/config.test.ts
+++ b/src/lib/__tests__/config.test.ts
@@ -1,16 +1,26 @@
 import type { FintocConfig } from '../../types.js'
+import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
 
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { clearConfig, CONFIG_DIR, CONFIG_PATH, readConfig, writeConfig } from '../config.js'
 
-vi.mock('node:fs')
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  unlinkSync: vi.fn(),
+}))
 vi.mock('node:os', () => ({
   homedir: () => '/mock-home',
 }))
-
-const { readConfig, writeConfig, clearConfig, CONFIG_DIR, CONFIG_PATH } =
-  await import('../config.js')
-
-const fs = await import('node:fs')
+vi.mock('../constants.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../constants.js')>()
+  return {
+    ...actual,
+    CONFIG_DIR_PERMISSIONS: 0o700,
+    CONFIG_FILE_PERMISSIONS: 0o600,
+  }
+})
 
 const fsError = (code: string): NodeJS.ErrnoException => {
   const err = new Error(code) as NodeJS.ErrnoException
@@ -34,7 +44,7 @@ describe('config', () => {
 
   describe('readConfig', () => {
     test('returns empty object when file does not exist', () => {
-      vi.mocked(fs.readFileSync).mockImplementation(() => {
+      vi.mocked(readFileSync).mockImplementation(() => {
         throw fsError('ENOENT')
       })
 
@@ -42,14 +52,14 @@ describe('config', () => {
     })
 
     test('parses valid TOML', () => {
-      vi.mocked(fs.readFileSync).mockReturnValue('secret_key = "sk_test_123"')
+      vi.mocked(readFileSync).mockReturnValue('secret_key = "sk_test_123"')
 
       const config = readConfig()
       expect(config).toEqual({ secret_key: 'sk_test_123' })
     })
 
     test('rethrows non-ENOENT errors', () => {
-      vi.mocked(fs.readFileSync).mockImplementation(() => {
+      vi.mocked(readFileSync).mockImplementation(() => {
         throw fsError('EACCES')
       })
 
@@ -59,17 +69,14 @@ describe('config', () => {
 
   describe('writeConfig', () => {
     test('creates directory and writes file with correct permissions', () => {
-      vi.mocked(fs.mkdirSync).mockReturnValue(undefined)
-      vi.mocked(fs.writeFileSync).mockReturnValue(undefined)
-
       const config: FintocConfig = { secret_key: 'sk_test_abc' }
       writeConfig(config)
 
-      expect(fs.mkdirSync).toHaveBeenCalledWith('/mock-home/.fintoc', {
+      expect(mkdirSync).toHaveBeenCalledWith('/mock-home/.fintoc', {
         recursive: true,
         mode: 0o700,
       })
-      expect(fs.writeFileSync).toHaveBeenCalledWith(
+      expect(writeFileSync).toHaveBeenCalledWith(
         '/mock-home/.fintoc/config.toml',
         expect.stringContaining('secret_key'),
         { mode: 0o600 },
@@ -77,27 +84,22 @@ describe('config', () => {
     })
 
     test('omits undefined values', () => {
-      vi.mocked(fs.mkdirSync).mockReturnValue(undefined)
-      vi.mocked(fs.writeFileSync).mockReturnValue(undefined)
-
       writeConfig({ secret_key: 'sk_test_abc' })
 
-      const written = vi.mocked(fs.writeFileSync).mock.calls[0]![1] as string
+      const written = vi.mocked(writeFileSync).mock.calls[0]![1] as string
       expect(written).not.toContain('jws_private_key')
     })
   })
 
   describe('clearConfig', () => {
     test('deletes the config file', () => {
-      vi.mocked(fs.unlinkSync).mockReturnValue(undefined)
-
       clearConfig()
 
-      expect(fs.unlinkSync).toHaveBeenCalledWith('/mock-home/.fintoc/config.toml')
+      expect(unlinkSync).toHaveBeenCalledWith('/mock-home/.fintoc/config.toml')
     })
 
     test('is silent when file does not exist', () => {
-      vi.mocked(fs.unlinkSync).mockImplementation(() => {
+      vi.mocked(unlinkSync).mockImplementation(() => {
         throw fsError('ENOENT')
       })
 
@@ -105,7 +107,7 @@ describe('config', () => {
     })
 
     test('rethrows non-ENOENT errors', () => {
-      vi.mocked(fs.unlinkSync).mockImplementation(() => {
+      vi.mocked(unlinkSync).mockImplementation(() => {
         throw fsError('EACCES')
       })
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,7 @@
 import { Fintoc } from 'fintoc'
 
 import { readConfig } from './config.js'
+import { DASHBOARD_API_KEYS_URL } from './constants.js'
 
 export type AuthSource = 'flag' | 'env' | 'config'
 
@@ -38,7 +39,7 @@ export const resolveAuth = (options?: { apiKey?: string }) => {
       '  Or:    export FINTOC_SECRET_KEY=sk_test_...',
       '  Or:    fintoc --api-key sk_test_... <command>',
       '',
-      '  Get your API keys at: https://dashboard.fintoc.com/api-keys',
+      `  Get your API keys at: ${DASHBOARD_API_KEYS_URL}`,
     ].join('\n'),
   )
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -25,7 +25,12 @@ export const resolveAuth = (options?: { apiKey?: string }) => {
   }
 
   const envKey = process.env.FINTOC_SECRET_KEY
-  if (envKey) {
+  if (envKey !== undefined) {
+    if (!envKey.trim()) {
+      throw new Error(
+        'FINTOC_SECRET_KEY is set but empty. Provide a valid key or unset the variable.',
+      )
+    }
     return { secretKey: envKey, source: 'env' as const }
   }
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -17,7 +17,10 @@ export type WhoamiResponse = {
 }
 
 export const resolveAuth = (options?: { apiKey?: string }) => {
-  if (options?.apiKey) {
+  if (options?.apiKey !== undefined) {
+    if (!options.apiKey.trim()) {
+      throw new Error('API key is empty. Provide a valid key with --api-key or remove the flag.')
+    }
     return { secretKey: options.apiKey, source: 'flag' as const }
   }
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -6,6 +6,8 @@ import { join } from 'node:path'
 
 import { parse, stringify } from 'smol-toml'
 
+import { CONFIG_DIR_PERMISSIONS, CONFIG_FILE_PERMISSIONS } from './constants.js'
+
 export const CONFIG_DIR = join(homedir(), '.fintoc')
 export const CONFIG_PATH = join(CONFIG_DIR, 'config.toml')
 
@@ -25,11 +27,11 @@ export const readConfig = (): FintocConfig => {
 }
 
 export const writeConfig = (config: FintocConfig) => {
-  mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 })
+  mkdirSync(CONFIG_DIR, { recursive: true, mode: CONFIG_DIR_PERMISSIONS })
 
   const clean = Object.fromEntries(Object.entries(config).filter(([, v]) => v !== undefined))
 
-  writeFileSync(CONFIG_PATH, stringify(clean), { mode: 0o600 })
+  writeFileSync(CONFIG_PATH, stringify(clean), { mode: CONFIG_FILE_PERMISSIONS })
 }
 
 export const clearConfig = () => {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,6 +1,9 @@
 export const API_HOST = 'api.fintoc.com'
 export const NPM_PACKAGE_NAME = '@fintoc/cli'
 export const DEFAULT_LIST_LIMIT = 10
+export const NPM_CHECK_TIMEOUT_MS = 10_000
+export const CONFIG_FILE_PERMISSIONS = 0o600
+export const CONFIG_DIR_PERMISSIONS = 0o700
 
 export const DASHBOARD_URL = 'https://dashboard.fintoc.com/'
 export const DASHBOARD_API_KEYS_URL = 'https://dashboard.fintoc.com/api-keys'

--- a/src/resources/__tests__/factory.test.ts
+++ b/src/resources/__tests__/factory.test.ts
@@ -84,795 +84,813 @@ const mockProcessExit = () => {
   })
 }
 
-beforeEach(() => {
-  vi.clearAllMocks()
-  vi.mocked(resolveAuth).mockReturnValue({ secretKey: 'sk_test_123', source: 'config' })
-  vi.mocked(createClient).mockReturnValue(mockClient as unknown as ReturnType<typeof createClient>)
-  vi.mocked(confirm).mockResolvedValue(true)
-})
-
-describe('factory: registerResourceCommands', () => {
-  test('registers subcommands for each verb', () => {
-    const program = createProgram()
-    const resourceCmd = program.commands.find((c) => c.name() === 'payment_intents')!
-
-    expect(resourceCmd).toBeDefined()
-
-    const subcommandNames = resourceCmd.commands.map((c) => c.name())
-    expect(subcommandNames).toContain('create')
-    expect(subcommandNames).toContain('get')
-    expect(subcommandNames).toContain('list')
-    expect(subcommandNames).toContain('delete')
+describe('factory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(resolveAuth).mockReturnValue({ secretKey: 'sk_test_123', source: 'config' })
+    vi.mocked(createClient).mockReturnValue(
+      mockClient as unknown as ReturnType<typeof createClient>,
+    )
+    vi.mocked(confirm).mockResolvedValue(true)
   })
 
-  test('only registers verbs from the resource def', () => {
-    const readOnlyResource: ResourceDef = {
-      ...testResource,
-      name: 'accounts',
-      cliCommand: 'accounts',
-      verbs: ['get', 'list'],
-    }
-
-    const program = createProgram(readOnlyResource)
-    const resourceCmd = program.commands.find((c) => c.name() === 'accounts')!
-    const subcommandNames = resourceCmd.commands.map((c) => c.name())
-
-    expect(subcommandNames).toContain('get')
-    expect(subcommandNames).toContain('list')
-    expect(subcommandNames).not.toContain('create')
-    expect(subcommandNames).not.toContain('delete')
-  })
-})
-
-describe('factory: create command', () => {
-  describe('when flags are valid', () => {
-    test('calls SDK create with parsed flags', async () => {
-      const mockResult = { serialize: () => ({ id: 'pi_123', amount: 10000, currency: 'CLP' }) }
-      mockManager.create.mockResolvedValue(mockResult)
-
-      const program = createProgram()
-      await program.parseAsync(
-        ['payment_intents', 'create', '--amount', '10000', '--currency', 'CLP'],
-        { from: 'user' },
-      )
-
-      expect(mockManager.create).toHaveBeenCalledWith({
-        amount: 10000,
-        currency: 'CLP',
-      })
-      expect(success).toHaveBeenCalled()
-      expect(printDetail).toHaveBeenCalledWith({ id: 'pi_123', amount: 10000, currency: 'CLP' })
-    })
-
-    test('converts kebab-case flags to snake_case for SDK', async () => {
-      const mockResult = { serialize: () => ({ id: 'pi_123' }) }
-      mockManager.create.mockResolvedValue(mockResult)
-
-      const program = createProgram()
-      await program.parseAsync(
-        [
-          'payment_intents',
-          'create',
-          '--amount',
-          '10000',
-          '--currency',
-          'CLP',
-          '--customer-email',
-          'test@example.com',
-        ],
-        { from: 'user' },
-      )
-
-      expect(mockManager.create).toHaveBeenCalledWith({
-        amount: 10000,
-        currency: 'CLP',
-        customer_email: 'test@example.com',
-      })
-    })
-
-    test('assembles nested flags into nested objects via nestedPath', async () => {
-      const nestedResource: ResourceDef = {
-        name: 'checkout_sessions',
-        displayName: 'checkout session',
-        cliCommand: 'checkout_sessions',
-        sdkMethod: 'paymentIntents',
-        sdkNamespace: 'v1',
-        verbs: ['create'],
-        priorityColumns: ['id'],
-        createFlags: [
-          { name: 'amount', type: 'integer', required: true },
-          { name: 'currency', type: 'string', required: true },
-          {
-            name: 'recipient-account-type',
-            type: 'string',
-            nestedPath: 'payment_method_options.payment_intent.recipient_account.type',
-          },
-          {
-            name: 'business-profile-tax-id',
-            type: 'string',
-            nestedPath: 'business_profile.tax_id',
-          },
-        ],
-        listFlags: [],
-      }
-
-      const mockResult = { serialize: () => ({ id: 'cs_123' }) }
-      mockManager.create.mockResolvedValue(mockResult)
-
-      const program = createProgram(nestedResource)
-      await program.parseAsync(
-        [
-          'checkout_sessions',
-          'create',
-          '--amount',
-          '5000',
-          '--currency',
-          'CLP',
-          '--recipient-account-type',
-          'checking_account',
-          '--business-profile-tax-id',
-          '11111111-1',
-        ],
-        { from: 'user' },
-      )
-
-      expect(mockManager.create).toHaveBeenCalledWith({
-        amount: 5000,
-        currency: 'CLP',
-        payment_method_options: {
-          payment_intent: {
-            recipient_account: {
-              type: 'checking_account',
-            },
-          },
-        },
-        business_profile: {
-          tax_id: '11111111-1',
-        },
-      })
-    })
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
-  describe('when --json flag is set', () => {
-    test('outputs JSON instead of detail view', async () => {
-      const mockResult = { serialize: () => ({ id: 'pi_123', amount: 10000 }) }
-      mockManager.create.mockResolvedValue(mockResult)
-
+  describe('registerResourceCommands', () => {
+    test('registers subcommands for each verb', () => {
       const program = createProgram()
-      await program.parseAsync(
-        ['--json', 'payment_intents', 'create', '--amount', '10000', '--currency', 'CLP'],
-        { from: 'user' },
-      )
+      const resourceCmd = program.commands.find((c) => c.name() === 'payment_intents')!
 
-      expect(printJson).toHaveBeenCalledWith({ id: 'pi_123', amount: 10000 })
-      expect(printDetail).not.toHaveBeenCalled()
-    })
-  })
+      expect(resourceCmd).toBeDefined()
 
-  describe('when number flag value is invalid', () => {
-    let exitSpy: ReturnType<typeof vi.spyOn>
-
-    beforeEach(() => {
-      exitSpy = mockProcessExit()
+      const subcommandNames = resourceCmd.commands.map((c) => c.name())
+      expect(subcommandNames).toContain('create')
+      expect(subcommandNames).toContain('get')
+      expect(subcommandNames).toContain('list')
+      expect(subcommandNames).toContain('delete')
     })
 
-    afterEach(() => {
-      exitSpy.mockRestore()
-    })
-
-    test('exits with error when value is not a number', async () => {
-      const program = createProgram()
-      await expect(
-        program.parseAsync(['payment_intents', 'create', '--amount', 'abc', '--currency', 'CLP'], {
-          from: 'user',
-        }),
-      ).rejects.toThrow('process.exit')
-
-      expect(error).toHaveBeenCalledWith(
-        expect.stringContaining("Invalid value 'abc' for flag --amount: expected a number"),
-      )
-      expect(mockManager.create).not.toHaveBeenCalled()
-    })
-
-    test('exits with error when value is a decimal', async () => {
-      const program = createProgram()
-      await expect(
-        program.parseAsync(['payment_intents', 'create', '--amount', '1.5', '--currency', 'CLP'], {
-          from: 'user',
-        }),
-      ).rejects.toThrow('process.exit')
-
-      expect(error).toHaveBeenCalledWith(
-        expect.stringContaining("Invalid value '1.5' for flag --amount: expected an integer"),
-      )
-      expect(mockManager.create).not.toHaveBeenCalled()
-    })
-
-    test('accepts valid integer values', async () => {
-      const mockResult = { serialize: () => ({ id: 'pi_123', amount: 10000 }) }
-      mockManager.create.mockResolvedValue(mockResult)
-
-      const program = createProgram()
-      await program.parseAsync(
-        ['payment_intents', 'create', '--amount', '10000', '--currency', 'CLP'],
-        { from: 'user' },
-      )
-
-      expect(mockManager.create).toHaveBeenCalledWith({ amount: 10000, currency: 'CLP' })
-    })
-  })
-
-  describe('when required flags are missing', () => {
-    let exitSpy: ReturnType<typeof vi.spyOn>
-
-    beforeEach(() => {
-      exitSpy = mockProcessExit()
-    })
-
-    afterEach(() => {
-      exitSpy.mockRestore()
-    })
-
-    test('exits with error listing missing flags', async () => {
-      const program = createProgram()
-      await expect(
-        program.parseAsync(['payment_intents', 'create', '--currency', 'CLP'], { from: 'user' }),
-      ).rejects.toThrow('process.exit')
-
-      expect(error).toHaveBeenCalledWith(expect.stringContaining('--amount'))
-    })
-
-    test('shows v2 prefix in usage hint for v2 resources', async () => {
-      const v2Resource: ResourceDef = {
+    test('only registers verbs from the resource def', () => {
+      const readOnlyResource: ResourceDef = {
         ...testResource,
-        name: 'transfers',
-        cliCommand: 'transfers',
-        sdkNamespace: 'v2',
+        name: 'accounts',
+        cliCommand: 'accounts',
+        verbs: ['get', 'list'],
       }
 
-      const program = createProgram(v2Resource)
-      await expect(
-        program.parseAsync(['transfers', 'create', '--currency', 'CLP'], { from: 'user' }),
-      ).rejects.toThrow('process.exit')
+      const program = createProgram(readOnlyResource)
+      const resourceCmd = program.commands.find((c) => c.name() === 'accounts')!
+      const subcommandNames = resourceCmd.commands.map((c) => c.name())
 
-      expect(log).toHaveBeenCalledWith(expect.stringContaining('fintoc v2 transfers create'))
+      expect(subcommandNames).toContain('get')
+      expect(subcommandNames).toContain('list')
+      expect(subcommandNames).not.toContain('create')
+      expect(subcommandNames).not.toContain('delete')
     })
   })
-})
 
-describe('factory: create --from-json', () => {
-  describe('when reading from file', () => {
-    test('reads JSON body from file and passes to SDK', async () => {
-      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ amount: 10000, currency: 'CLP' }))
+  describe('create command', () => {
+    describe('when flags are valid', () => {
+      test('calls SDK create with parsed flags', async () => {
+        const mockResult = { serialize: () => ({ id: 'pi_123', amount: 10000, currency: 'CLP' }) }
+        mockManager.create.mockResolvedValue(mockResult)
 
-      const mockResult = { serialize: () => ({ id: 'pi_123', amount: 10000 }) }
-      mockManager.create.mockResolvedValue(mockResult)
+        const program = createProgram()
+        await program.parseAsync(
+          ['payment_intents', 'create', '--amount', '10000', '--currency', 'CLP'],
+          { from: 'user' },
+        )
 
-      const program = createProgram()
-      await program.parseAsync(['payment_intents', 'create', '--from-json', 'payload.json'], {
-        from: 'user',
-      })
-
-      expect(readFileSync).toHaveBeenCalledWith('payload.json', 'utf-8')
-      expect(mockManager.create).toHaveBeenCalledWith({ amount: 10000, currency: 'CLP' })
-      expect(success).toHaveBeenCalled()
-    })
-
-    test('reads JSON body from stdin when path is "-"', async () => {
-      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ amount: 5000, currency: 'MXN' }))
-
-      const mockResult = { serialize: () => ({ id: 'pi_456' }) }
-      mockManager.create.mockResolvedValue(mockResult)
-
-      const program = createProgram()
-      await program.parseAsync(['payment_intents', 'create', '--from-json', '-'], { from: 'user' })
-
-      expect(readFileSync).toHaveBeenCalledWith(0, 'utf-8')
-      expect(mockManager.create).toHaveBeenCalledWith({ amount: 5000, currency: 'MXN' })
-    })
-
-    test('JSON preserves extra fields not in createFlags', async () => {
-      vi.mocked(readFileSync).mockReturnValue(
-        JSON.stringify({
+        expect(mockManager.create).toHaveBeenCalledWith({
           amount: 10000,
           currency: 'CLP',
-          line_items: [{ name: 'Item 1', amount: 5000 }],
-          metadata: { order_id: 'ord_123' },
-        }),
-      )
-
-      const mockResult = { serialize: () => ({ id: 'pi_complex' }) }
-      mockManager.create.mockResolvedValue(mockResult)
-
-      const program = createProgram()
-      await program.parseAsync(['payment_intents', 'create', '--from-json', 'complex.json'], {
-        from: 'user',
+        })
+        expect(success).toHaveBeenCalled()
+        expect(printDetail).toHaveBeenCalledWith({ id: 'pi_123', amount: 10000, currency: 'CLP' })
       })
 
-      expect(mockManager.create).toHaveBeenCalledWith({
-        amount: 10000,
-        currency: 'CLP',
-        line_items: [{ name: 'Item 1', amount: 5000 }],
-        metadata: { order_id: 'ord_123' },
+      test('converts kebab-case flags to snake_case for SDK', async () => {
+        const mockResult = { serialize: () => ({ id: 'pi_123' }) }
+        mockManager.create.mockResolvedValue(mockResult)
+
+        const program = createProgram()
+        await program.parseAsync(
+          [
+            'payment_intents',
+            'create',
+            '--amount',
+            '10000',
+            '--currency',
+            'CLP',
+            '--customer-email',
+            'test@example.com',
+          ],
+          { from: 'user' },
+        )
+
+        expect(mockManager.create).toHaveBeenCalledWith({
+          amount: 10000,
+          currency: 'CLP',
+          customer_email: 'test@example.com',
+        })
       })
-    })
 
-    test('skips required flag validation when --from-json is provided', async () => {
-      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ amount: 10000, currency: 'CLP' }))
+      test('assembles nested flags into nested objects via nestedPath', async () => {
+        const nestedResource: ResourceDef = {
+          name: 'checkout_sessions',
+          displayName: 'checkout session',
+          cliCommand: 'checkout_sessions',
+          sdkMethod: 'paymentIntents',
+          sdkNamespace: 'v1',
+          verbs: ['create'],
+          priorityColumns: ['id'],
+          createFlags: [
+            { name: 'amount', type: 'integer', required: true },
+            { name: 'currency', type: 'string', required: true },
+            {
+              name: 'recipient-account-type',
+              type: 'string',
+              nestedPath: 'payment_method_options.payment_intent.recipient_account.type',
+            },
+            {
+              name: 'business-profile-tax-id',
+              type: 'string',
+              nestedPath: 'business_profile.tax_id',
+            },
+          ],
+          listFlags: [],
+        }
 
-      const mockResult = { serialize: () => ({ id: 'pi_abc' }) }
-      mockManager.create.mockResolvedValue(mockResult)
+        const mockResult = { serialize: () => ({ id: 'cs_123' }) }
+        mockManager.create.mockResolvedValue(mockResult)
 
-      const program = createProgram()
-      await program.parseAsync(['payment_intents', 'create', '--from-json', 'payload.json'], {
-        from: 'user',
-      })
+        const program = createProgram(nestedResource)
+        await program.parseAsync(
+          [
+            'checkout_sessions',
+            'create',
+            '--amount',
+            '5000',
+            '--currency',
+            'CLP',
+            '--recipient-account-type',
+            'checking_account',
+            '--business-profile-tax-id',
+            '11111111-1',
+          ],
+          { from: 'user' },
+        )
 
-      expect(error).not.toHaveBeenCalled()
-      expect(mockManager.create).toHaveBeenCalledWith({ amount: 10000, currency: 'CLP' })
-    })
-  })
-
-  describe('when flags override JSON values', () => {
-    test('flags take precedence over JSON', async () => {
-      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ amount: 10000, currency: 'CLP' }))
-
-      const mockResult = { serialize: () => ({ id: 'pi_789' }) }
-      mockManager.create.mockResolvedValue(mockResult)
-
-      const program = createProgram()
-      await program.parseAsync(
-        ['payment_intents', 'create', '--from-json', 'base.json', '--currency', 'MXN'],
-        { from: 'user' },
-      )
-
-      expect(mockManager.create).toHaveBeenCalledWith({
-        amount: 10000,
-        currency: 'MXN',
-      })
-    })
-
-    test('deep merges nested flag values over JSON', async () => {
-      const nestedResource: ResourceDef = {
-        name: 'checkout_sessions',
-        displayName: 'checkout session',
-        cliCommand: 'checkout_sessions',
-        sdkMethod: 'paymentIntents',
-        sdkNamespace: 'v1',
-        verbs: ['create'],
-        priorityColumns: ['id'],
-        createFlags: [
-          { name: 'amount', type: 'integer', required: true },
-          { name: 'currency', type: 'string', required: true },
-          {
-            name: 'recipient-account-type',
-            type: 'string',
-            nestedPath: 'payment_method_options.payment_intent.recipient_account.type',
-          },
-        ],
-        listFlags: [],
-      }
-
-      vi.mocked(readFileSync).mockReturnValue(
-        JSON.stringify({
+        expect(mockManager.create).toHaveBeenCalledWith({
           amount: 5000,
           currency: 'CLP',
           payment_method_options: {
             payment_intent: {
               recipient_account: {
                 type: 'checking_account',
+              },
+            },
+          },
+          business_profile: {
+            tax_id: '11111111-1',
+          },
+        })
+      })
+    })
+
+    describe('when --json flag is set', () => {
+      test('outputs JSON instead of detail view', async () => {
+        const mockResult = { serialize: () => ({ id: 'pi_123', amount: 10000 }) }
+        mockManager.create.mockResolvedValue(mockResult)
+
+        const program = createProgram()
+        await program.parseAsync(
+          ['--json', 'payment_intents', 'create', '--amount', '10000', '--currency', 'CLP'],
+          { from: 'user' },
+        )
+
+        expect(printJson).toHaveBeenCalledWith({ id: 'pi_123', amount: 10000 })
+        expect(printDetail).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when number flag value is invalid', () => {
+      let exitSpy: ReturnType<typeof vi.spyOn>
+
+      beforeEach(() => {
+        exitSpy = mockProcessExit()
+      })
+
+      afterEach(() => {
+        exitSpy.mockRestore()
+      })
+
+      test('exits with error when value is not a number', async () => {
+        const program = createProgram()
+        await expect(
+          program.parseAsync(
+            ['payment_intents', 'create', '--amount', 'abc', '--currency', 'CLP'],
+            {
+              from: 'user',
+            },
+          ),
+        ).rejects.toThrow('process.exit')
+
+        expect(error).toHaveBeenCalledWith(
+          expect.stringContaining("Invalid value 'abc' for flag --amount: expected a number"),
+        )
+        expect(mockManager.create).not.toHaveBeenCalled()
+      })
+
+      test('exits with error when value is a decimal', async () => {
+        const program = createProgram()
+        await expect(
+          program.parseAsync(
+            ['payment_intents', 'create', '--amount', '1.5', '--currency', 'CLP'],
+            {
+              from: 'user',
+            },
+          ),
+        ).rejects.toThrow('process.exit')
+
+        expect(error).toHaveBeenCalledWith(
+          expect.stringContaining("Invalid value '1.5' for flag --amount: expected an integer"),
+        )
+        expect(mockManager.create).not.toHaveBeenCalled()
+      })
+
+      test('accepts valid integer values', async () => {
+        const mockResult = { serialize: () => ({ id: 'pi_123', amount: 10000 }) }
+        mockManager.create.mockResolvedValue(mockResult)
+
+        const program = createProgram()
+        await program.parseAsync(
+          ['payment_intents', 'create', '--amount', '10000', '--currency', 'CLP'],
+          { from: 'user' },
+        )
+
+        expect(mockManager.create).toHaveBeenCalledWith({ amount: 10000, currency: 'CLP' })
+      })
+    })
+
+    describe('when required flags are missing', () => {
+      let exitSpy: ReturnType<typeof vi.spyOn>
+
+      beforeEach(() => {
+        exitSpy = mockProcessExit()
+      })
+
+      afterEach(() => {
+        exitSpy.mockRestore()
+      })
+
+      test('exits with error listing missing flags', async () => {
+        const program = createProgram()
+        await expect(
+          program.parseAsync(['payment_intents', 'create', '--currency', 'CLP'], { from: 'user' }),
+        ).rejects.toThrow('process.exit')
+
+        expect(error).toHaveBeenCalledWith(expect.stringContaining('--amount'))
+      })
+
+      test('shows v2 prefix in usage hint for v2 resources', async () => {
+        const v2Resource: ResourceDef = {
+          ...testResource,
+          name: 'transfers',
+          cliCommand: 'transfers',
+          sdkNamespace: 'v2',
+        }
+
+        const program = createProgram(v2Resource)
+        await expect(
+          program.parseAsync(['transfers', 'create', '--currency', 'CLP'], { from: 'user' }),
+        ).rejects.toThrow('process.exit')
+
+        expect(log).toHaveBeenCalledWith(expect.stringContaining('fintoc v2 transfers create'))
+      })
+    })
+  })
+
+  describe('create --from-json', () => {
+    describe('when reading from file', () => {
+      test('reads JSON body from file and passes to SDK', async () => {
+        vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ amount: 10000, currency: 'CLP' }))
+
+        const mockResult = { serialize: () => ({ id: 'pi_123', amount: 10000 }) }
+        mockManager.create.mockResolvedValue(mockResult)
+
+        const program = createProgram()
+        await program.parseAsync(['payment_intents', 'create', '--from-json', 'payload.json'], {
+          from: 'user',
+        })
+
+        expect(readFileSync).toHaveBeenCalledWith('payload.json', 'utf-8')
+        expect(mockManager.create).toHaveBeenCalledWith({ amount: 10000, currency: 'CLP' })
+        expect(success).toHaveBeenCalled()
+      })
+
+      test('reads JSON body from stdin when path is "-"', async () => {
+        vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ amount: 5000, currency: 'MXN' }))
+
+        const mockResult = { serialize: () => ({ id: 'pi_456' }) }
+        mockManager.create.mockResolvedValue(mockResult)
+
+        const program = createProgram()
+        await program.parseAsync(['payment_intents', 'create', '--from-json', '-'], {
+          from: 'user',
+        })
+
+        expect(readFileSync).toHaveBeenCalledWith(0, 'utf-8')
+        expect(mockManager.create).toHaveBeenCalledWith({ amount: 5000, currency: 'MXN' })
+      })
+
+      test('JSON preserves extra fields not in createFlags', async () => {
+        vi.mocked(readFileSync).mockReturnValue(
+          JSON.stringify({
+            amount: 10000,
+            currency: 'CLP',
+            line_items: [{ name: 'Item 1', amount: 5000 }],
+            metadata: { order_id: 'ord_123' },
+          }),
+        )
+
+        const mockResult = { serialize: () => ({ id: 'pi_complex' }) }
+        mockManager.create.mockResolvedValue(mockResult)
+
+        const program = createProgram()
+        await program.parseAsync(['payment_intents', 'create', '--from-json', 'complex.json'], {
+          from: 'user',
+        })
+
+        expect(mockManager.create).toHaveBeenCalledWith({
+          amount: 10000,
+          currency: 'CLP',
+          line_items: [{ name: 'Item 1', amount: 5000 }],
+          metadata: { order_id: 'ord_123' },
+        })
+      })
+
+      test('skips required flag validation when --from-json is provided', async () => {
+        vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ amount: 10000, currency: 'CLP' }))
+
+        const mockResult = { serialize: () => ({ id: 'pi_abc' }) }
+        mockManager.create.mockResolvedValue(mockResult)
+
+        const program = createProgram()
+        await program.parseAsync(['payment_intents', 'create', '--from-json', 'payload.json'], {
+          from: 'user',
+        })
+
+        expect(error).not.toHaveBeenCalled()
+        expect(mockManager.create).toHaveBeenCalledWith({ amount: 10000, currency: 'CLP' })
+      })
+    })
+
+    describe('when flags override JSON values', () => {
+      test('flags take precedence over JSON', async () => {
+        vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ amount: 10000, currency: 'CLP' }))
+
+        const mockResult = { serialize: () => ({ id: 'pi_789' }) }
+        mockManager.create.mockResolvedValue(mockResult)
+
+        const program = createProgram()
+        await program.parseAsync(
+          ['payment_intents', 'create', '--from-json', 'base.json', '--currency', 'MXN'],
+          { from: 'user' },
+        )
+
+        expect(mockManager.create).toHaveBeenCalledWith({
+          amount: 10000,
+          currency: 'MXN',
+        })
+      })
+
+      test('deep merges nested flag values over JSON', async () => {
+        const nestedResource: ResourceDef = {
+          name: 'checkout_sessions',
+          displayName: 'checkout session',
+          cliCommand: 'checkout_sessions',
+          sdkMethod: 'paymentIntents',
+          sdkNamespace: 'v1',
+          verbs: ['create'],
+          priorityColumns: ['id'],
+          createFlags: [
+            { name: 'amount', type: 'integer', required: true },
+            { name: 'currency', type: 'string', required: true },
+            {
+              name: 'recipient-account-type',
+              type: 'string',
+              nestedPath: 'payment_method_options.payment_intent.recipient_account.type',
+            },
+          ],
+          listFlags: [],
+        }
+
+        vi.mocked(readFileSync).mockReturnValue(
+          JSON.stringify({
+            amount: 5000,
+            currency: 'CLP',
+            payment_method_options: {
+              payment_intent: {
+                recipient_account: {
+                  type: 'checking_account',
+                  number: '12345678',
+                },
+              },
+            },
+          }),
+        )
+
+        const mockResult = { serialize: () => ({ id: 'cs_123' }) }
+        mockManager.create.mockResolvedValue(mockResult)
+
+        const program = createProgram(nestedResource)
+        await program.parseAsync(
+          [
+            'checkout_sessions',
+            'create',
+            '--from-json',
+            'base.json',
+            '--recipient-account-type',
+            'savings_account',
+          ],
+          { from: 'user' },
+        )
+
+        expect(mockManager.create).toHaveBeenCalledWith({
+          amount: 5000,
+          currency: 'CLP',
+          payment_method_options: {
+            payment_intent: {
+              recipient_account: {
+                type: 'savings_account',
                 number: '12345678',
               },
             },
           },
-        }),
-      )
+        })
+      })
+    })
 
-      const mockResult = { serialize: () => ({ id: 'cs_123' }) }
-      mockManager.create.mockResolvedValue(mockResult)
+    describe('when input is invalid', () => {
+      let exitSpy: ReturnType<typeof vi.spyOn>
 
-      const program = createProgram(nestedResource)
-      await program.parseAsync(
-        [
-          'checkout_sessions',
-          'create',
-          '--from-json',
-          'base.json',
-          '--recipient-account-type',
-          'savings_account',
+      beforeEach(() => {
+        exitSpy = mockProcessExit()
+      })
+
+      afterEach(() => {
+        exitSpy.mockRestore()
+      })
+
+      test('exits with error on invalid JSON', async () => {
+        vi.mocked(readFileSync).mockReturnValue('not valid json')
+
+        const program = createProgram()
+        await expect(
+          program.parseAsync(['payment_intents', 'create', '--from-json', 'bad.json'], {
+            from: 'user',
+          }),
+        ).rejects.toThrow('process.exit')
+
+        expect(error).toHaveBeenCalledWith(expect.stringContaining('invalid JSON'))
+      })
+
+      test('exits with error when file does not exist', async () => {
+        const enoent = new Error(
+          "ENOENT: no such file or directory, open 'missing.json'",
+        ) as Error & {
+          code: string
+        }
+        enoent.code = 'ENOENT'
+        vi.mocked(readFileSync).mockImplementation(() => {
+          throw enoent
+        })
+
+        const program = createProgram()
+        await expect(
+          program.parseAsync(['payment_intents', 'create', '--from-json', 'missing.json'], {
+            from: 'user',
+          }),
+        ).rejects.toThrow('process.exit')
+
+        expect(error).toHaveBeenCalledWith("--from-json: file 'missing.json' not found")
+      })
+
+      test('exits with error when stdin is a TTY', async () => {
+        const originalIsTTY = process.stdin.isTTY
+        Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+
+        const program = createProgram()
+        await expect(
+          program.parseAsync(['payment_intents', 'create', '--from-json', '-'], {
+            from: 'user',
+          }),
+        ).rejects.toThrow('process.exit')
+
+        expect(error).toHaveBeenCalledWith(
+          '--from-json -: no input on stdin. Pipe a file or use a path instead',
+        )
+
+        Object.defineProperty(process.stdin, 'isTTY', {
+          value: originalIsTTY,
+          configurable: true,
+        })
+      })
+
+      test('exits with error when JSON is not an object', async () => {
+        vi.mocked(readFileSync).mockReturnValue(JSON.stringify([1, 2, 3]))
+
+        const program = createProgram()
+        await expect(
+          program.parseAsync(['payment_intents', 'create', '--from-json', 'array.json'], {
+            from: 'user',
+          }),
+        ).rejects.toThrow('process.exit')
+
+        expect(error).toHaveBeenCalledWith('--from-json must contain a JSON object')
+      })
+    })
+  })
+
+  describe('get command', () => {
+    describe('when resource exists', () => {
+      test('calls SDK get with ID and shows full object', async () => {
+        const mockResult = { serialize: () => ({ id: 'pi_123', amount: 10000 }) }
+        mockManager.get.mockResolvedValue(mockResult)
+
+        const program = createProgram()
+        await program.parseAsync(['payment_intents', 'get', 'pi_123'], { from: 'user' })
+
+        expect(mockManager.get).toHaveBeenCalledWith('pi_123')
+        expect(printDetail).toHaveBeenCalledWith({ id: 'pi_123', amount: 10000 })
+      })
+    })
+
+    describe('when --json flag is set', () => {
+      test('outputs JSON instead of detail view', async () => {
+        const mockResult = { serialize: () => ({ id: 'pi_123' }) }
+        mockManager.get.mockResolvedValue(mockResult)
+
+        const program = createProgram()
+        await program.parseAsync(['--json', 'payment_intents', 'get', 'pi_123'], { from: 'user' })
+
+        expect(printJson).toHaveBeenCalledWith({ id: 'pi_123' })
+      })
+    })
+  })
+
+  describe('list command', () => {
+    describe('when listing resources', () => {
+      test('calls SDK list with lazy mode and respects limit', async () => {
+        const items = Array.from({ length: 20 }, (_, i) => ({
+          serialize: () => ({ id: `pi_${i}` }),
+        }))
+        mockManager.list.mockResolvedValue(asyncGenerator(items))
+
+        const program = createProgram()
+        await program.parseAsync(['payment_intents', 'list', '--limit', '5'], { from: 'user' })
+
+        expect(mockManager.list).toHaveBeenCalledWith(expect.objectContaining({ lazy: true }))
+        expect(printTable).toHaveBeenCalledWith(
+          expect.objectContaining({
+            rows: expect.arrayContaining([expect.objectContaining({ id: 'pi_0' })]),
+          }),
+        )
+        // Should have only 5 items due to limit
+        const call = vi.mocked(printTable).mock.calls[0][0]
+        expect(call.rows).toHaveLength(5)
+      })
+
+      test('passes filter flags to SDK', async () => {
+        mockManager.list.mockResolvedValue(asyncGenerator([]))
+
+        const program = createProgram()
+        await program.parseAsync(['payment_intents', 'list', '--status', 'succeeded'], {
+          from: 'user',
+        })
+
+        expect(mockManager.list).toHaveBeenCalledWith(
+          expect.objectContaining({ status: 'succeeded', lazy: true }),
+        )
+      })
+
+      test('defaults limit to 10', async () => {
+        const items = Array.from({ length: 15 }, (_, i) => ({
+          serialize: () => ({ id: `pi_${i}` }),
+        }))
+        mockManager.list.mockResolvedValue(asyncGenerator(items))
+
+        const program = createProgram()
+        await program.parseAsync(['payment_intents', 'list'], { from: 'user' })
+
+        const call = vi.mocked(printTable).mock.calls[0][0]
+        expect(call.rows).toHaveLength(10)
+      })
+    })
+
+    describe('when --json flag is set', () => {
+      test('outputs JSON instead of table', async () => {
+        const items = [{ serialize: () => ({ id: 'pi_0' }) }]
+        mockManager.list.mockResolvedValue(asyncGenerator(items))
+
+        const program = createProgram()
+        await program.parseAsync(['--json', 'payment_intents', 'list'], { from: 'user' })
+
+        expect(printJson).toHaveBeenCalledWith([{ id: 'pi_0' }])
+        expect(printTable).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when --limit is invalid', () => {
+      let exitSpy: ReturnType<typeof vi.spyOn>
+
+      beforeEach(() => {
+        exitSpy = mockProcessExit()
+      })
+
+      afterEach(() => {
+        exitSpy.mockRestore()
+      })
+
+      test.each(['abc', '0', '-5'])('exits with error when --limit is %s', async (value) => {
+        const program = createProgram()
+        await expect(
+          program.parseAsync(['payment_intents', 'list', '--limit', value], { from: 'user' }),
+        ).rejects.toThrow('process.exit')
+
+        expect(error).toHaveBeenCalledWith('--limit must be a positive number')
+        expect(mockManager.list).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('delete command', () => {
+    describe('when --yes flag skips confirmation', () => {
+      test('calls SDK delete directly', async () => {
+        mockManager.delete.mockResolvedValue('deleted')
+
+        const program = createProgram()
+        await program.parseAsync(['payment_intents', 'delete', 'pi_123', '--yes'], { from: 'user' })
+
+        expect(mockManager.delete).toHaveBeenCalledWith('pi_123')
+        expect(success).toHaveBeenCalledWith(expect.stringContaining('pi_123'))
+      })
+    })
+
+    describe('when running in non-TTY without --yes', () => {
+      let exitSpy: ReturnType<typeof vi.spyOn>
+      let originalIsTTY: boolean | undefined
+
+      beforeEach(() => {
+        exitSpy = mockProcessExit()
+        originalIsTTY = process.stdin.isTTY
+        Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true })
+      })
+
+      afterEach(() => {
+        Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
+        exitSpy.mockRestore()
+      })
+
+      test('exits with error', async () => {
+        const program = createProgram()
+        await expect(
+          program.parseAsync(['payment_intents', 'delete', 'pi_123'], { from: 'user' }),
+        ).rejects.toThrow('process.exit')
+
+        expect(mockManager.delete).not.toHaveBeenCalled()
+        expect(error).toHaveBeenCalledWith(expect.stringContaining('--yes'))
+      })
+    })
+
+    describe('when user declines confirmation', () => {
+      test('aborts without calling SDK', async () => {
+        vi.mocked(confirm).mockResolvedValue(false)
+
+        const originalIsTTY = process.stdin.isTTY
+        Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+
+        const program = createProgram()
+        await program.parseAsync(['payment_intents', 'delete', 'pi_123'], { from: 'user' })
+
+        expect(mockManager.delete).not.toHaveBeenCalled()
+        expect(log).toHaveBeenCalledWith('Aborted.')
+
+        Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
+      })
+    })
+  })
+
+  describe('--jws-private-key flag', () => {
+    describe('when resource.needsJws is true', () => {
+      const jwsResource: ResourceDef = {
+        name: 'transfers',
+        displayName: 'transfer',
+        cliCommand: 'transfers',
+        sdkMethod: 'paymentIntents',
+        sdkNamespace: 'v1',
+        verbs: ['create'],
+        needsJws: true,
+        priorityColumns: ['id'],
+        createFlags: [
+          { name: 'amount', type: 'integer', required: true },
+          { name: 'currency', type: 'string', required: true },
         ],
-        { from: 'user' },
-      )
-
-      expect(mockManager.create).toHaveBeenCalledWith({
-        amount: 5000,
-        currency: 'CLP',
-        payment_method_options: {
-          payment_intent: {
-            recipient_account: {
-              type: 'savings_account',
-              number: '12345678',
-            },
-          },
-        },
-      })
-    })
-  })
-
-  describe('when input is invalid', () => {
-    let exitSpy: ReturnType<typeof vi.spyOn>
-
-    beforeEach(() => {
-      exitSpy = mockProcessExit()
-    })
-
-    afterEach(() => {
-      exitSpy.mockRestore()
-    })
-
-    test('exits with error on invalid JSON', async () => {
-      vi.mocked(readFileSync).mockReturnValue('not valid json')
-
-      const program = createProgram()
-      await expect(
-        program.parseAsync(['payment_intents', 'create', '--from-json', 'bad.json'], {
-          from: 'user',
-        }),
-      ).rejects.toThrow('process.exit')
-
-      expect(error).toHaveBeenCalledWith(expect.stringContaining('invalid JSON'))
-    })
-
-    test('exits with error when file does not exist', async () => {
-      const enoent = new Error(
-        "ENOENT: no such file or directory, open 'missing.json'",
-      ) as Error & {
-        code: string
+        listFlags: [],
       }
-      enoent.code = 'ENOENT'
-      vi.mocked(readFileSync).mockImplementation(() => {
-        throw enoent
+
+      test('adds --jws-private-key flag to create command', () => {
+        const program = createProgram(jwsResource)
+        const resourceCmd = program.commands.find((c) => c.name() === 'transfers')!
+        const createCmd = resourceCmd.commands.find((c) => c.name() === 'create')!
+        const options = createCmd.options.map((o) => o.long)
+
+        expect(options).toContain('--jws-private-key')
       })
 
-      const program = createProgram()
-      await expect(
-        program.parseAsync(['payment_intents', 'create', '--from-json', 'missing.json'], {
-          from: 'user',
-        }),
-      ).rejects.toThrow('process.exit')
+      test('passes jws key path to createClient when flag is provided', async () => {
+        const mockResult = { serialize: () => ({ id: 'tr_123' }) }
+        mockManager.create.mockResolvedValue(mockResult)
 
-      expect(error).toHaveBeenCalledWith("--from-json: file 'missing.json' not found")
-    })
+        const program = createProgram(jwsResource)
+        await program.parseAsync(
+          [
+            'transfers',
+            'create',
+            '--amount',
+            '10000',
+            '--currency',
+            'CLP',
+            '--jws-private-key',
+            '/path/to/key.pem',
+          ],
+          { from: 'user' },
+        )
 
-    test('exits with error when stdin is a TTY', async () => {
-      const originalIsTTY = process.stdin.isTTY
-      Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
-
-      const program = createProgram()
-      await expect(
-        program.parseAsync(['payment_intents', 'create', '--from-json', '-'], {
-          from: 'user',
-        }),
-      ).rejects.toThrow('process.exit')
-
-      expect(error).toHaveBeenCalledWith(
-        '--from-json -: no input on stdin. Pipe a file or use a path instead',
-      )
-
-      Object.defineProperty(process.stdin, 'isTTY', {
-        value: originalIsTTY,
-        configurable: true,
+        expect(createClient).toHaveBeenCalledWith('sk_test_123', '/path/to/key.pem')
       })
     })
 
-    test('exits with error when JSON is not an object', async () => {
-      vi.mocked(readFileSync).mockReturnValue(JSON.stringify([1, 2, 3]))
+    describe('when resource.needsJws is false', () => {
+      test('does not add --jws-private-key flag', () => {
+        const program = createProgram()
+        const resourceCmd = program.commands.find((c) => c.name() === 'payment_intents')!
+        const createCmd = resourceCmd.commands.find((c) => c.name() === 'create')!
+        const options = createCmd.options.map((o) => o.long)
 
-      const program = createProgram()
-      await expect(
-        program.parseAsync(['payment_intents', 'create', '--from-json', 'array.json'], {
-          from: 'user',
-        }),
-      ).rejects.toThrow('process.exit')
-
-      expect(error).toHaveBeenCalledWith('--from-json must contain a JSON object')
-    })
-  })
-})
-
-describe('factory: get command', () => {
-  describe('when resource exists', () => {
-    test('calls SDK get with ID and shows full object', async () => {
-      const mockResult = { serialize: () => ({ id: 'pi_123', amount: 10000 }) }
-      mockManager.get.mockResolvedValue(mockResult)
-
-      const program = createProgram()
-      await program.parseAsync(['payment_intents', 'get', 'pi_123'], { from: 'user' })
-
-      expect(mockManager.get).toHaveBeenCalledWith('pi_123')
-      expect(printDetail).toHaveBeenCalledWith({ id: 'pi_123', amount: 10000 })
-    })
-  })
-
-  describe('when --json flag is set', () => {
-    test('outputs JSON instead of detail view', async () => {
-      const mockResult = { serialize: () => ({ id: 'pi_123' }) }
-      mockManager.get.mockResolvedValue(mockResult)
-
-      const program = createProgram()
-      await program.parseAsync(['--json', 'payment_intents', 'get', 'pi_123'], { from: 'user' })
-
-      expect(printJson).toHaveBeenCalledWith({ id: 'pi_123' })
-    })
-  })
-})
-
-describe('factory: list command', () => {
-  describe('when listing resources', () => {
-    test('calls SDK list with lazy mode and respects limit', async () => {
-      const items = Array.from({ length: 20 }, (_, i) => ({
-        serialize: () => ({ id: `pi_${i}` }),
-      }))
-      mockManager.list.mockResolvedValue(asyncGenerator(items))
-
-      const program = createProgram()
-      await program.parseAsync(['payment_intents', 'list', '--limit', '5'], { from: 'user' })
-
-      expect(mockManager.list).toHaveBeenCalledWith(expect.objectContaining({ lazy: true }))
-      expect(printTable).toHaveBeenCalledWith(
-        expect.objectContaining({
-          rows: expect.arrayContaining([expect.objectContaining({ id: 'pi_0' })]),
-        }),
-      )
-      // Should have only 5 items due to limit
-      const call = vi.mocked(printTable).mock.calls[0][0]
-      expect(call.rows).toHaveLength(5)
-    })
-
-    test('passes filter flags to SDK', async () => {
-      mockManager.list.mockResolvedValue(asyncGenerator([]))
-
-      const program = createProgram()
-      await program.parseAsync(['payment_intents', 'list', '--status', 'succeeded'], {
-        from: 'user',
+        expect(options).not.toContain('--jws-private-key')
       })
-
-      expect(mockManager.list).toHaveBeenCalledWith(
-        expect.objectContaining({ status: 'succeeded', lazy: true }),
-      )
-    })
-
-    test('defaults limit to 10', async () => {
-      const items = Array.from({ length: 15 }, (_, i) => ({
-        serialize: () => ({ id: `pi_${i}` }),
-      }))
-      mockManager.list.mockResolvedValue(asyncGenerator(items))
-
-      const program = createProgram()
-      await program.parseAsync(['payment_intents', 'list'], { from: 'user' })
-
-      const call = vi.mocked(printTable).mock.calls[0][0]
-      expect(call.rows).toHaveLength(10)
     })
   })
 
-  describe('when --json flag is set', () => {
-    test('outputs JSON instead of table', async () => {
-      const items = [{ serialize: () => ({ id: 'pi_0' }) }]
-      mockManager.list.mockResolvedValue(asyncGenerator(items))
+  describe('v2 namespace', () => {
+    const v2Manager = {
+      list: vi.fn(),
+    }
 
-      const program = createProgram()
-      await program.parseAsync(['--json', 'payment_intents', 'list'], { from: 'user' })
-
-      expect(printJson).toHaveBeenCalledWith([{ id: 'pi_0' }])
-      expect(printTable).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('when --limit is invalid', () => {
-    let exitSpy: ReturnType<typeof vi.spyOn>
-
-    beforeEach(() => {
-      exitSpy = mockProcessExit()
-    })
-
-    afterEach(() => {
-      exitSpy.mockRestore()
-    })
-
-    test.each(['abc', '0', '-5'])('exits with error when --limit is %s', async (value) => {
-      const program = createProgram()
-      await expect(
-        program.parseAsync(['payment_intents', 'list', '--limit', value], { from: 'user' }),
-      ).rejects.toThrow('process.exit')
-
-      expect(error).toHaveBeenCalledWith('--limit must be a positive number')
-      expect(mockManager.list).not.toHaveBeenCalled()
-    })
-  })
-})
-
-describe('factory: delete command', () => {
-  describe('when --yes flag skips confirmation', () => {
-    test('calls SDK delete directly', async () => {
-      mockManager.delete.mockResolvedValue('deleted')
-
-      const program = createProgram()
-      await program.parseAsync(['payment_intents', 'delete', 'pi_123', '--yes'], { from: 'user' })
-
-      expect(mockManager.delete).toHaveBeenCalledWith('pi_123')
-      expect(success).toHaveBeenCalledWith(expect.stringContaining('pi_123'))
-    })
-  })
-
-  describe('when running in non-TTY without --yes', () => {
-    let exitSpy: ReturnType<typeof vi.spyOn>
-    let originalIsTTY: boolean | undefined
-
-    beforeEach(() => {
-      exitSpy = mockProcessExit()
-      originalIsTTY = process.stdin.isTTY
-      Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true })
-    })
-
-    afterEach(() => {
-      Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
-      exitSpy.mockRestore()
-    })
-
-    test('exits with error', async () => {
-      const program = createProgram()
-      await expect(
-        program.parseAsync(['payment_intents', 'delete', 'pi_123'], { from: 'user' }),
-      ).rejects.toThrow('process.exit')
-
-      expect(mockManager.delete).not.toHaveBeenCalled()
-      expect(error).toHaveBeenCalledWith(expect.stringContaining('--yes'))
-    })
-  })
-
-  describe('when user declines confirmation', () => {
-    test('aborts without calling SDK', async () => {
-      vi.mocked(confirm).mockResolvedValue(false)
-
-      const originalIsTTY = process.stdin.isTTY
-      Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
-
-      const program = createProgram()
-      await program.parseAsync(['payment_intents', 'delete', 'pi_123'], { from: 'user' })
-
-      expect(mockManager.delete).not.toHaveBeenCalled()
-      expect(log).toHaveBeenCalledWith('Aborted.')
-
-      Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
-    })
-  })
-})
-
-describe('factory: --jws-private-key flag', () => {
-  describe('when resource.needsJws is true', () => {
-    const jwsResource: ResourceDef = {
+    const v2Resource: ResourceDef = {
       name: 'transfers',
       displayName: 'transfer',
       cliCommand: 'transfers',
-      sdkMethod: 'paymentIntents',
-      sdkNamespace: 'v1',
-      verbs: ['create'],
-      needsJws: true,
-      priorityColumns: ['id'],
-      createFlags: [
-        { name: 'amount', type: 'integer', required: true },
-        { name: 'currency', type: 'string', required: true },
-      ],
+      sdkMethod: 'transfers',
+      sdkNamespace: 'v2',
+      verbs: ['list'],
+      priorityColumns: ['id', 'amount', 'status'],
       listFlags: [],
     }
 
-    test('adds --jws-private-key flag to create command', () => {
-      const program = createProgram(jwsResource)
-      const resourceCmd = program.commands.find((c) => c.name() === 'transfers')!
-      const createCmd = resourceCmd.commands.find((c) => c.name() === 'create')!
-      const options = createCmd.options.map((o) => o.long)
-
-      expect(options).toContain('--jws-private-key')
-    })
-
-    test('passes jws key path to createClient when flag is provided', async () => {
-      const mockResult = { serialize: () => ({ id: 'tr_123' }) }
-      mockManager.create.mockResolvedValue(mockResult)
-
-      const program = createProgram(jwsResource)
-      await program.parseAsync(
-        [
-          'transfers',
-          'create',
-          '--amount',
-          '10000',
-          '--currency',
-          'CLP',
-          '--jws-private-key',
-          '/path/to/key.pem',
-        ],
-        { from: 'user' },
+    const setupV2Client = () => {
+      const v2Client = { v2: { transfers: v2Manager } }
+      vi.mocked(createClient).mockReturnValue(
+        v2Client as unknown as ReturnType<typeof createClient>,
       )
-
-      expect(createClient).toHaveBeenCalledWith('sk_test_123', '/path/to/key.pem')
-    })
-  })
-
-  describe('when resource.needsJws is false', () => {
-    test('does not add --jws-private-key flag', () => {
-      const program = createProgram()
-      const resourceCmd = program.commands.find((c) => c.name() === 'payment_intents')!
-      const createCmd = resourceCmd.commands.find((c) => c.name() === 'create')!
-      const options = createCmd.options.map((o) => o.long)
-
-      expect(options).not.toContain('--jws-private-key')
-    })
-  })
-})
-
-describe('factory: v2 namespace', () => {
-  const v2Manager = {
-    list: vi.fn(),
-  }
-
-  const v2Resource: ResourceDef = {
-    name: 'transfers',
-    displayName: 'transfer',
-    cliCommand: 'transfers',
-    sdkMethod: 'transfers',
-    sdkNamespace: 'v2',
-    verbs: ['list'],
-    priorityColumns: ['id', 'amount', 'status'],
-    listFlags: [],
-  }
-
-  const setupV2Client = () => {
-    const v2Client = { v2: { transfers: v2Manager } }
-    vi.mocked(createClient).mockReturnValue(v2Client as unknown as ReturnType<typeof createClient>)
-  }
-
-  describe('when registered directly on a program', () => {
-    test('routes to the v2 SDK namespace', async () => {
-      setupV2Client()
-      v2Manager.list.mockResolvedValue(asyncGenerator([]))
-
-      const program = createProgram(v2Resource)
-      await program.parseAsync(['transfers', 'list'], { from: 'user' })
-
-      expect(v2Manager.list).toHaveBeenCalled()
-    })
-  })
-
-  describe('when nested under a v2 subcommand (root > v2 > resource > action)', () => {
-    const createV2Program = () => {
-      const root = new Command()
-      root.exitOverride()
-      root.option('--api-key <key>', 'Override API key').option('--json', 'Output as JSON')
-      const v2Cmd = root.command('v2').description('API v2 resources')
-      registerResourceCommands(v2Cmd, [v2Resource])
-      return root
     }
 
-    test('routes to the v2 SDK namespace', async () => {
-      setupV2Client()
-      v2Manager.list.mockResolvedValue(asyncGenerator([]))
+    describe('when registered directly on a program', () => {
+      test('routes to the v2 SDK namespace', async () => {
+        setupV2Client()
+        v2Manager.list.mockResolvedValue(asyncGenerator([]))
 
-      const program = createV2Program()
-      await program.parseAsync(['v2', 'transfers', 'list'], { from: 'user' })
+        const program = createProgram(v2Resource)
+        await program.parseAsync(['transfers', 'list'], { from: 'user' })
 
-      expect(v2Manager.list).toHaveBeenCalled()
+        expect(v2Manager.list).toHaveBeenCalled()
+      })
     })
 
-    test('resolves root --json flag through nested commands', async () => {
-      setupV2Client()
-      v2Manager.list.mockResolvedValue(asyncGenerator([{ serialize: () => ({ id: 'tr_1' }) }]))
+    describe('when nested under a v2 subcommand (root > v2 > resource > action)', () => {
+      const createV2Program = () => {
+        const root = new Command()
+        root.exitOverride()
+        root.option('--api-key <key>', 'Override API key').option('--json', 'Output as JSON')
+        const v2Cmd = root.command('v2').description('API v2 resources')
+        registerResourceCommands(v2Cmd, [v2Resource])
+        return root
+      }
 
-      const program = createV2Program()
-      await program.parseAsync(['--json', 'v2', 'transfers', 'list'], { from: 'user' })
+      test('routes to the v2 SDK namespace', async () => {
+        setupV2Client()
+        v2Manager.list.mockResolvedValue(asyncGenerator([]))
 
-      expect(printJson).toHaveBeenCalledWith([{ id: 'tr_1' }])
-      expect(printTable).not.toHaveBeenCalled()
+        const program = createV2Program()
+        await program.parseAsync(['v2', 'transfers', 'list'], { from: 'user' })
+
+        expect(v2Manager.list).toHaveBeenCalled()
+      })
+
+      test('resolves root --json flag through nested commands', async () => {
+        setupV2Client()
+        v2Manager.list.mockResolvedValue(asyncGenerator([{ serialize: () => ({ id: 'tr_1' }) }]))
+
+        const program = createV2Program()
+        await program.parseAsync(['--json', 'v2', 'transfers', 'list'], { from: 'user' })
+
+        expect(printJson).toHaveBeenCalledWith([{ id: 'tr_1' }])
+        expect(printTable).not.toHaveBeenCalled()
+      })
     })
   })
 })

--- a/src/resources/__tests__/factory.test.ts
+++ b/src/resources/__tests__/factory.test.ts
@@ -279,7 +279,7 @@ describe('factory', () => {
         ).rejects.toThrow('process.exit')
 
         expect(error).toHaveBeenCalledWith(
-          expect.stringContaining("Invalid value 'abc' for flag --amount: expected a number"),
+          expect.stringContaining("Invalid value 'abc' for flag --amount: expected an integer"),
         )
         expect(mockManager.create).not.toHaveBeenCalled()
       })

--- a/src/resources/__tests__/factory.test.ts
+++ b/src/resources/__tests__/factory.test.ts
@@ -1,21 +1,11 @@
 import type { ResourceDef } from '../../types.js'
+import { readFileSync } from 'node:fs'
+import { confirm } from '@inquirer/prompts'
 import { Command } from 'commander'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { createClient, resolveAuth } from '../../lib/auth.js'
 import { error, log, printDetail, printJson, printTable, success } from '../../lib/output.js'
 import { registerResourceCommands } from '../factory.js'
-
-const { mockManager, mockClient } = vi.hoisted(() => {
-  const mockManager = {
-    create: vi.fn(),
-    get: vi.fn(),
-    list: vi.fn(),
-    delete: vi.fn(),
-  }
-  const mockClient = {
-    paymentIntents: mockManager,
-  }
-  return { mockManager, mockClient }
-})
 
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>()
@@ -23,8 +13,8 @@ vi.mock('node:fs', async (importOriginal) => {
 })
 
 vi.mock('../../lib/auth.js', () => ({
-  resolveAuth: vi.fn(() => ({ secretKey: 'sk_test_123', source: 'config' })),
-  createClient: vi.fn(() => mockClient),
+  resolveAuth: vi.fn(),
+  createClient: vi.fn(),
 }))
 
 vi.mock('../../lib/config.js', () => ({
@@ -35,15 +25,25 @@ vi.mock('../../lib/output.js', () => ({
   log: vi.fn(),
   success: vi.fn(),
   error: vi.fn(),
-  warn: vi.fn(),
   printTable: vi.fn(),
   printJson: vi.fn(),
   printDetail: vi.fn(),
 }))
 
 vi.mock('@inquirer/prompts', () => ({
-  confirm: vi.fn(() => true),
+  confirm: vi.fn(),
 }))
+
+const mockManager = {
+  create: vi.fn(),
+  get: vi.fn(),
+  list: vi.fn(),
+  delete: vi.fn(),
+}
+
+const mockClient = {
+  paymentIntents: mockManager,
+}
 
 // Mock async generator helper
 const asyncGenerator = (items: { serialize: () => Record<string, unknown> }[]) => {
@@ -78,15 +78,20 @@ const createProgram = (resource: ResourceDef = testResource) => {
   return program
 }
 
+const mockProcessExit = () => {
+  return vi.spyOn(process, 'exit').mockImplementation(() => {
+    throw new Error('process.exit')
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(resolveAuth).mockReturnValue({ secretKey: 'sk_test_123', source: 'config' })
+  vi.mocked(createClient).mockReturnValue(mockClient as unknown as ReturnType<typeof createClient>)
+  vi.mocked(confirm).mockResolvedValue(true)
+})
+
 describe('factory: registerResourceCommands', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-
   test('registers subcommands for each verb', () => {
     const program = createProgram()
     const resourceCmd = program.commands.find((c) => c.name() === 'payment_intents')!
@@ -120,352 +125,332 @@ describe('factory: registerResourceCommands', () => {
 })
 
 describe('factory: create command', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
+  describe('when flags are valid', () => {
+    test('calls SDK create with parsed flags', async () => {
+      const mockResult = { serialize: () => ({ id: 'pi_123', amount: 10000, currency: 'CLP' }) }
+      mockManager.create.mockResolvedValue(mockResult)
 
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
+      const program = createProgram()
+      await program.parseAsync(
+        ['payment_intents', 'create', '--amount', '10000', '--currency', 'CLP'],
+        { from: 'user' },
+      )
 
-  test('calls SDK create with parsed flags', async () => {
-    const mockResult = { serialize: () => ({ id: 'pi_123', amount: 10000, currency: 'CLP' }) }
-    mockManager.create.mockResolvedValue(mockResult)
-
-    const program = createProgram()
-    await program.parseAsync(
-      ['payment_intents', 'create', '--amount', '10000', '--currency', 'CLP'],
-      { from: 'user' },
-    )
-
-    expect(mockManager.create).toHaveBeenCalledWith({
-      amount: 10000,
-      currency: 'CLP',
-    })
-    expect(success).toHaveBeenCalled()
-    expect(printDetail).toHaveBeenCalledWith({ id: 'pi_123', amount: 10000, currency: 'CLP' })
-  })
-
-  test('converts kebab-case flags to snake_case for SDK', async () => {
-    const mockResult = { serialize: () => ({ id: 'pi_123' }) }
-    mockManager.create.mockResolvedValue(mockResult)
-
-    const program = createProgram()
-    await program.parseAsync(
-      [
-        'payment_intents',
-        'create',
-        '--amount',
-        '10000',
-        '--currency',
-        'CLP',
-        '--customer-email',
-        'test@example.com',
-      ],
-      { from: 'user' },
-    )
-
-    expect(mockManager.create).toHaveBeenCalledWith({
-      amount: 10000,
-      currency: 'CLP',
-      customer_email: 'test@example.com',
-    })
-  })
-
-  test('exits with error on missing required flags', async () => {
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('process.exit')
-    })
-
-    const program = createProgram()
-    await expect(
-      program.parseAsync(['payment_intents', 'create', '--currency', 'CLP'], { from: 'user' }),
-    ).rejects.toThrow('process.exit')
-
-    expect(error).toHaveBeenCalledWith(expect.stringContaining('--amount'))
-    exitSpy.mockRestore()
-  })
-
-  test('shows v2 prefix in usage hint for v2 resources', async () => {
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('process.exit')
-    })
-
-    const v2Resource: ResourceDef = {
-      ...testResource,
-      name: 'transfers',
-      cliCommand: 'transfers',
-      sdkNamespace: 'v2',
-    }
-
-    const program = createProgram(v2Resource)
-    await expect(
-      program.parseAsync(['transfers', 'create', '--currency', 'CLP'], { from: 'user' }),
-    ).rejects.toThrow('process.exit')
-
-    expect(log).toHaveBeenCalledWith(expect.stringContaining('fintoc v2 transfers create'))
-    exitSpy.mockRestore()
-  })
-
-  test('outputs JSON when --json flag is set', async () => {
-    const mockResult = { serialize: () => ({ id: 'pi_123', amount: 10000 }) }
-    mockManager.create.mockResolvedValue(mockResult)
-
-    const program = createProgram()
-    await program.parseAsync(
-      ['--json', 'payment_intents', 'create', '--amount', '10000', '--currency', 'CLP'],
-      { from: 'user' },
-    )
-
-    expect(printJson).toHaveBeenCalledWith({ id: 'pi_123', amount: 10000 })
-    expect(printDetail).not.toHaveBeenCalled()
-  })
-
-  test('assembles nested flags into nested objects via nestedPath', async () => {
-    const nestedResource: ResourceDef = {
-      name: 'checkout_sessions',
-      displayName: 'checkout session',
-      cliCommand: 'checkout_sessions',
-      sdkMethod: 'paymentIntents',
-      sdkNamespace: 'v1',
-      verbs: ['create'],
-      priorityColumns: ['id'],
-      createFlags: [
-        { name: 'amount', type: 'number', required: true },
-        { name: 'currency', type: 'string', required: true },
-        {
-          name: 'recipient-account-type',
-          type: 'string',
-          nestedPath: 'payment_method_options.payment_intent.recipient_account.type',
-        },
-        {
-          name: 'business-profile-tax-id',
-          type: 'string',
-          nestedPath: 'business_profile.tax_id',
-        },
-      ],
-      listFlags: [],
-    }
-
-    const mockResult = { serialize: () => ({ id: 'cs_123' }) }
-    mockManager.create.mockResolvedValue(mockResult)
-
-    const program = createProgram(nestedResource)
-    await program.parseAsync(
-      [
-        'checkout_sessions',
-        'create',
-        '--amount',
-        '5000',
-        '--currency',
-        'CLP',
-        '--recipient-account-type',
-        'checking_account',
-        '--business-profile-tax-id',
-        '11111111-1',
-      ],
-      { from: 'user' },
-    )
-
-    expect(mockManager.create).toHaveBeenCalledWith({
-      amount: 5000,
-      currency: 'CLP',
-      payment_method_options: {
-        payment_intent: {
-          recipient_account: {
-            type: 'checking_account',
-          },
-        },
-      },
-      business_profile: {
-        tax_id: '11111111-1',
-      },
-    })
-  })
-})
-
-describe('factory: create --from-json', () => {
-  let readFileSyncMock: ReturnType<typeof vi.fn>
-
-  beforeEach(async () => {
-    vi.clearAllMocks()
-    const fs = await import('node:fs')
-    readFileSyncMock = vi.mocked(fs.readFileSync)
-  })
-
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-
-  test('reads JSON body from file and passes to SDK', async () => {
-    readFileSyncMock.mockReturnValue(JSON.stringify({ amount: 10000, currency: 'CLP' }))
-
-    const mockResult = { serialize: () => ({ id: 'pi_123', amount: 10000 }) }
-    mockManager.create.mockResolvedValue(mockResult)
-
-    const program = createProgram()
-    await program.parseAsync(['payment_intents', 'create', '--from-json', 'payload.json'], {
-      from: 'user',
-    })
-
-    expect(readFileSyncMock).toHaveBeenCalledWith('payload.json', 'utf-8')
-    expect(mockManager.create).toHaveBeenCalledWith({ amount: 10000, currency: 'CLP' })
-    expect(success).toHaveBeenCalled()
-  })
-
-  test('reads JSON body from stdin when path is "-"', async () => {
-    readFileSyncMock.mockReturnValue(JSON.stringify({ amount: 5000, currency: 'MXN' }))
-
-    const mockResult = { serialize: () => ({ id: 'pi_456' }) }
-    mockManager.create.mockResolvedValue(mockResult)
-
-    const program = createProgram()
-    await program.parseAsync(['payment_intents', 'create', '--from-json', '-'], { from: 'user' })
-
-    expect(readFileSyncMock).toHaveBeenCalledWith(0, 'utf-8')
-    expect(mockManager.create).toHaveBeenCalledWith({ amount: 5000, currency: 'MXN' })
-  })
-
-  test('flags override JSON values', async () => {
-    readFileSyncMock.mockReturnValue(JSON.stringify({ amount: 10000, currency: 'CLP' }))
-
-    const mockResult = { serialize: () => ({ id: 'pi_789' }) }
-    mockManager.create.mockResolvedValue(mockResult)
-
-    const program = createProgram()
-    await program.parseAsync(
-      ['payment_intents', 'create', '--from-json', 'base.json', '--currency', 'MXN'],
-      { from: 'user' },
-    )
-
-    expect(mockManager.create).toHaveBeenCalledWith({
-      amount: 10000,
-      currency: 'MXN',
-    })
-  })
-
-  test('skips required flag validation when --from-json is provided', async () => {
-    readFileSyncMock.mockReturnValue(JSON.stringify({ amount: 10000, currency: 'CLP' }))
-
-    const mockResult = { serialize: () => ({ id: 'pi_abc' }) }
-    mockManager.create.mockResolvedValue(mockResult)
-
-    const program = createProgram()
-    await program.parseAsync(['payment_intents', 'create', '--from-json', 'payload.json'], {
-      from: 'user',
-    })
-
-    expect(error).not.toHaveBeenCalled()
-    expect(mockManager.create).toHaveBeenCalledWith({ amount: 10000, currency: 'CLP' })
-  })
-
-  test('JSON preserves extra fields not in createFlags', async () => {
-    readFileSyncMock.mockReturnValue(
-      JSON.stringify({
+      expect(mockManager.create).toHaveBeenCalledWith({
         amount: 10000,
         currency: 'CLP',
-        line_items: [{ name: 'Item 1', amount: 5000 }],
-        metadata: { order_id: 'ord_123' },
-      }),
-    )
-
-    const mockResult = { serialize: () => ({ id: 'pi_complex' }) }
-    mockManager.create.mockResolvedValue(mockResult)
-
-    const program = createProgram()
-    await program.parseAsync(['payment_intents', 'create', '--from-json', 'complex.json'], {
-      from: 'user',
+      })
+      expect(success).toHaveBeenCalled()
+      expect(printDetail).toHaveBeenCalledWith({ id: 'pi_123', amount: 10000, currency: 'CLP' })
     })
 
-    expect(mockManager.create).toHaveBeenCalledWith({
-      amount: 10000,
-      currency: 'CLP',
-      line_items: [{ name: 'Item 1', amount: 5000 }],
-      metadata: { order_id: 'ord_123' },
+    test('converts kebab-case flags to snake_case for SDK', async () => {
+      const mockResult = { serialize: () => ({ id: 'pi_123' }) }
+      mockManager.create.mockResolvedValue(mockResult)
+
+      const program = createProgram()
+      await program.parseAsync(
+        [
+          'payment_intents',
+          'create',
+          '--amount',
+          '10000',
+          '--currency',
+          'CLP',
+          '--customer-email',
+          'test@example.com',
+        ],
+        { from: 'user' },
+      )
+
+      expect(mockManager.create).toHaveBeenCalledWith({
+        amount: 10000,
+        currency: 'CLP',
+        customer_email: 'test@example.com',
+      })
     })
-  })
 
-  test('deep merges nested flag values over JSON', async () => {
-    const nestedResource: ResourceDef = {
-      name: 'checkout_sessions',
-      displayName: 'checkout session',
-      cliCommand: 'checkout_sessions',
-      sdkMethod: 'paymentIntents',
-      sdkNamespace: 'v1',
-      verbs: ['create'],
-      priorityColumns: ['id'],
-      createFlags: [
-        { name: 'amount', type: 'number', required: true },
-        { name: 'currency', type: 'string', required: true },
-        {
-          name: 'recipient-account-type',
-          type: 'string',
-          nestedPath: 'payment_method_options.payment_intent.recipient_account.type',
-        },
-      ],
-      listFlags: [],
-    }
+    test('assembles nested flags into nested objects via nestedPath', async () => {
+      const nestedResource: ResourceDef = {
+        name: 'checkout_sessions',
+        displayName: 'checkout session',
+        cliCommand: 'checkout_sessions',
+        sdkMethod: 'paymentIntents',
+        sdkNamespace: 'v1',
+        verbs: ['create'],
+        priorityColumns: ['id'],
+        createFlags: [
+          { name: 'amount', type: 'number', required: true },
+          { name: 'currency', type: 'string', required: true },
+          {
+            name: 'recipient-account-type',
+            type: 'string',
+            nestedPath: 'payment_method_options.payment_intent.recipient_account.type',
+          },
+          {
+            name: 'business-profile-tax-id',
+            type: 'string',
+            nestedPath: 'business_profile.tax_id',
+          },
+        ],
+        listFlags: [],
+      }
 
-    readFileSyncMock.mockReturnValue(
-      JSON.stringify({
+      const mockResult = { serialize: () => ({ id: 'cs_123' }) }
+      mockManager.create.mockResolvedValue(mockResult)
+
+      const program = createProgram(nestedResource)
+      await program.parseAsync(
+        [
+          'checkout_sessions',
+          'create',
+          '--amount',
+          '5000',
+          '--currency',
+          'CLP',
+          '--recipient-account-type',
+          'checking_account',
+          '--business-profile-tax-id',
+          '11111111-1',
+        ],
+        { from: 'user' },
+      )
+
+      expect(mockManager.create).toHaveBeenCalledWith({
         amount: 5000,
         currency: 'CLP',
         payment_method_options: {
           payment_intent: {
             recipient_account: {
               type: 'checking_account',
+            },
+          },
+        },
+        business_profile: {
+          tax_id: '11111111-1',
+        },
+      })
+    })
+  })
+
+  describe('when --json flag is set', () => {
+    test('outputs JSON instead of detail view', async () => {
+      const mockResult = { serialize: () => ({ id: 'pi_123', amount: 10000 }) }
+      mockManager.create.mockResolvedValue(mockResult)
+
+      const program = createProgram()
+      await program.parseAsync(
+        ['--json', 'payment_intents', 'create', '--amount', '10000', '--currency', 'CLP'],
+        { from: 'user' },
+      )
+
+      expect(printJson).toHaveBeenCalledWith({ id: 'pi_123', amount: 10000 })
+      expect(printDetail).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when required flags are missing', () => {
+    test('exits with error listing missing flags', async () => {
+      const exitSpy = mockProcessExit()
+
+      const program = createProgram()
+      await expect(
+        program.parseAsync(['payment_intents', 'create', '--currency', 'CLP'], { from: 'user' }),
+      ).rejects.toThrow('process.exit')
+
+      expect(error).toHaveBeenCalledWith(expect.stringContaining('--amount'))
+      exitSpy.mockRestore()
+    })
+
+    test('shows v2 prefix in usage hint for v2 resources', async () => {
+      const exitSpy = mockProcessExit()
+
+      const v2Resource: ResourceDef = {
+        ...testResource,
+        name: 'transfers',
+        cliCommand: 'transfers',
+        sdkNamespace: 'v2',
+      }
+
+      const program = createProgram(v2Resource)
+      await expect(
+        program.parseAsync(['transfers', 'create', '--currency', 'CLP'], { from: 'user' }),
+      ).rejects.toThrow('process.exit')
+
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('fintoc v2 transfers create'))
+      exitSpy.mockRestore()
+    })
+  })
+})
+
+describe('factory: create --from-json', () => {
+  describe('when reading from file', () => {
+    test('reads JSON body from file and passes to SDK', async () => {
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ amount: 10000, currency: 'CLP' }))
+
+      const mockResult = { serialize: () => ({ id: 'pi_123', amount: 10000 }) }
+      mockManager.create.mockResolvedValue(mockResult)
+
+      const program = createProgram()
+      await program.parseAsync(['payment_intents', 'create', '--from-json', 'payload.json'], {
+        from: 'user',
+      })
+
+      expect(readFileSync).toHaveBeenCalledWith('payload.json', 'utf-8')
+      expect(mockManager.create).toHaveBeenCalledWith({ amount: 10000, currency: 'CLP' })
+      expect(success).toHaveBeenCalled()
+    })
+
+    test('reads JSON body from stdin when path is "-"', async () => {
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ amount: 5000, currency: 'MXN' }))
+
+      const mockResult = { serialize: () => ({ id: 'pi_456' }) }
+      mockManager.create.mockResolvedValue(mockResult)
+
+      const program = createProgram()
+      await program.parseAsync(['payment_intents', 'create', '--from-json', '-'], { from: 'user' })
+
+      expect(readFileSync).toHaveBeenCalledWith(0, 'utf-8')
+      expect(mockManager.create).toHaveBeenCalledWith({ amount: 5000, currency: 'MXN' })
+    })
+
+    test('JSON preserves extra fields not in createFlags', async () => {
+      vi.mocked(readFileSync).mockReturnValue(
+        JSON.stringify({
+          amount: 10000,
+          currency: 'CLP',
+          line_items: [{ name: 'Item 1', amount: 5000 }],
+          metadata: { order_id: 'ord_123' },
+        }),
+      )
+
+      const mockResult = { serialize: () => ({ id: 'pi_complex' }) }
+      mockManager.create.mockResolvedValue(mockResult)
+
+      const program = createProgram()
+      await program.parseAsync(['payment_intents', 'create', '--from-json', 'complex.json'], {
+        from: 'user',
+      })
+
+      expect(mockManager.create).toHaveBeenCalledWith({
+        amount: 10000,
+        currency: 'CLP',
+        line_items: [{ name: 'Item 1', amount: 5000 }],
+        metadata: { order_id: 'ord_123' },
+      })
+    })
+
+    test('skips required flag validation when --from-json is provided', async () => {
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ amount: 10000, currency: 'CLP' }))
+
+      const mockResult = { serialize: () => ({ id: 'pi_abc' }) }
+      mockManager.create.mockResolvedValue(mockResult)
+
+      const program = createProgram()
+      await program.parseAsync(['payment_intents', 'create', '--from-json', 'payload.json'], {
+        from: 'user',
+      })
+
+      expect(error).not.toHaveBeenCalled()
+      expect(mockManager.create).toHaveBeenCalledWith({ amount: 10000, currency: 'CLP' })
+    })
+  })
+
+  describe('when flags override JSON values', () => {
+    test('flags take precedence over JSON', async () => {
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ amount: 10000, currency: 'CLP' }))
+
+      const mockResult = { serialize: () => ({ id: 'pi_789' }) }
+      mockManager.create.mockResolvedValue(mockResult)
+
+      const program = createProgram()
+      await program.parseAsync(
+        ['payment_intents', 'create', '--from-json', 'base.json', '--currency', 'MXN'],
+        { from: 'user' },
+      )
+
+      expect(mockManager.create).toHaveBeenCalledWith({
+        amount: 10000,
+        currency: 'MXN',
+      })
+    })
+
+    test('deep merges nested flag values over JSON', async () => {
+      const nestedResource: ResourceDef = {
+        name: 'checkout_sessions',
+        displayName: 'checkout session',
+        cliCommand: 'checkout_sessions',
+        sdkMethod: 'paymentIntents',
+        sdkNamespace: 'v1',
+        verbs: ['create'],
+        priorityColumns: ['id'],
+        createFlags: [
+          { name: 'amount', type: 'number', required: true },
+          { name: 'currency', type: 'string', required: true },
+          {
+            name: 'recipient-account-type',
+            type: 'string',
+            nestedPath: 'payment_method_options.payment_intent.recipient_account.type',
+          },
+        ],
+        listFlags: [],
+      }
+
+      vi.mocked(readFileSync).mockReturnValue(
+        JSON.stringify({
+          amount: 5000,
+          currency: 'CLP',
+          payment_method_options: {
+            payment_intent: {
+              recipient_account: {
+                type: 'checking_account',
+                number: '12345678',
+              },
+            },
+          },
+        }),
+      )
+
+      const mockResult = { serialize: () => ({ id: 'cs_123' }) }
+      mockManager.create.mockResolvedValue(mockResult)
+
+      const program = createProgram(nestedResource)
+      await program.parseAsync(
+        [
+          'checkout_sessions',
+          'create',
+          '--from-json',
+          'base.json',
+          '--recipient-account-type',
+          'savings_account',
+        ],
+        { from: 'user' },
+      )
+
+      expect(mockManager.create).toHaveBeenCalledWith({
+        amount: 5000,
+        currency: 'CLP',
+        payment_method_options: {
+          payment_intent: {
+            recipient_account: {
+              type: 'savings_account',
               number: '12345678',
             },
           },
         },
-      }),
-    )
-
-    const mockResult = { serialize: () => ({ id: 'cs_123' }) }
-    mockManager.create.mockResolvedValue(mockResult)
-
-    const program = createProgram(nestedResource)
-    await program.parseAsync(
-      [
-        'checkout_sessions',
-        'create',
-        '--from-json',
-        'base.json',
-        '--recipient-account-type',
-        'savings_account',
-      ],
-      { from: 'user' },
-    )
-
-    expect(mockManager.create).toHaveBeenCalledWith({
-      amount: 5000,
-      currency: 'CLP',
-      payment_method_options: {
-        payment_intent: {
-          recipient_account: {
-            type: 'savings_account',
-            number: '12345678',
-          },
-        },
-      },
+      })
     })
   })
 
-  describe('error cases', () => {
+  describe('when input is invalid', () => {
     let exitSpy: ReturnType<typeof vi.spyOn>
 
     beforeEach(() => {
-      exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
-        throw new Error('process.exit')
-      })
-    })
-
-    afterEach(() => {
-      exitSpy.mockRestore()
+      exitSpy = mockProcessExit()
     })
 
     test('exits with error on invalid JSON', async () => {
-      readFileSyncMock.mockReturnValue('not valid json')
+      vi.mocked(readFileSync).mockReturnValue('not valid json')
 
       const program = createProgram()
       await expect(
@@ -475,6 +460,7 @@ describe('factory: create --from-json', () => {
       ).rejects.toThrow('process.exit')
 
       expect(error).toHaveBeenCalledWith(expect.stringContaining('invalid JSON'))
+      exitSpy.mockRestore()
     })
 
     test('exits with error when file does not exist', async () => {
@@ -484,7 +470,7 @@ describe('factory: create --from-json', () => {
         code: string
       }
       enoent.code = 'ENOENT'
-      readFileSyncMock.mockImplementation(() => {
+      vi.mocked(readFileSync).mockImplementation(() => {
         throw enoent
       })
 
@@ -496,6 +482,7 @@ describe('factory: create --from-json', () => {
       ).rejects.toThrow('process.exit')
 
       expect(error).toHaveBeenCalledWith("--from-json: file 'missing.json' not found")
+      exitSpy.mockRestore()
     })
 
     test('exits with error when stdin is a TTY', async () => {
@@ -517,10 +504,11 @@ describe('factory: create --from-json', () => {
         value: originalIsTTY,
         configurable: true,
       })
+      exitSpy.mockRestore()
     })
 
     test('exits with error when JSON is not an object', async () => {
-      readFileSyncMock.mockReturnValue(JSON.stringify([1, 2, 3]))
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify([1, 2, 3]))
 
       const program = createProgram()
       await expect(
@@ -530,223 +518,169 @@ describe('factory: create --from-json', () => {
       ).rejects.toThrow('process.exit')
 
       expect(error).toHaveBeenCalledWith('--from-json must contain a JSON object')
+      exitSpy.mockRestore()
     })
   })
 })
 
 describe('factory: get command', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
+  describe('when resource exists', () => {
+    test('calls SDK get with ID and shows full object', async () => {
+      const mockResult = { serialize: () => ({ id: 'pi_123', amount: 10000 }) }
+      mockManager.get.mockResolvedValue(mockResult)
+
+      const program = createProgram()
+      await program.parseAsync(['payment_intents', 'get', 'pi_123'], { from: 'user' })
+
+      expect(mockManager.get).toHaveBeenCalledWith('pi_123')
+      expect(printDetail).toHaveBeenCalledWith({ id: 'pi_123', amount: 10000 })
+    })
   })
 
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
+  describe('when --json flag is set', () => {
+    test('outputs JSON instead of detail view', async () => {
+      const mockResult = { serialize: () => ({ id: 'pi_123' }) }
+      mockManager.get.mockResolvedValue(mockResult)
 
-  test('calls SDK get with ID and shows full object', async () => {
-    const mockResult = { serialize: () => ({ id: 'pi_123', amount: 10000 }) }
-    mockManager.get.mockResolvedValue(mockResult)
+      const program = createProgram()
+      await program.parseAsync(['--json', 'payment_intents', 'get', 'pi_123'], { from: 'user' })
 
-    const program = createProgram()
-    await program.parseAsync(['payment_intents', 'get', 'pi_123'], { from: 'user' })
-
-    expect(mockManager.get).toHaveBeenCalledWith('pi_123')
-    expect(printDetail).toHaveBeenCalledWith({ id: 'pi_123', amount: 10000 })
-  })
-
-  test('outputs JSON when --json flag is set', async () => {
-    const mockResult = { serialize: () => ({ id: 'pi_123' }) }
-    mockManager.get.mockResolvedValue(mockResult)
-
-    const program = createProgram()
-    await program.parseAsync(['--json', 'payment_intents', 'get', 'pi_123'], { from: 'user' })
-
-    expect(printJson).toHaveBeenCalledWith({ id: 'pi_123' })
+      expect(printJson).toHaveBeenCalledWith({ id: 'pi_123' })
+    })
   })
 })
 
 describe('factory: list command', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
+  describe('when listing resources', () => {
+    test('calls SDK list with lazy mode and respects limit', async () => {
+      const items = Array.from({ length: 20 }, (_, i) => ({
+        serialize: () => ({ id: `pi_${i}` }),
+      }))
+      mockManager.list.mockResolvedValue(asyncGenerator(items))
 
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
+      const program = createProgram()
+      await program.parseAsync(['payment_intents', 'list', '--limit', '5'], { from: 'user' })
 
-  test('calls SDK list with lazy mode and respects limit', async () => {
-    const items = Array.from({ length: 20 }, (_, i) => ({
-      serialize: () => ({ id: `pi_${i}` }),
-    }))
-    mockManager.list.mockResolvedValue(asyncGenerator(items))
-
-    const program = createProgram()
-    await program.parseAsync(['payment_intents', 'list', '--limit', '5'], { from: 'user' })
-
-    expect(mockManager.list).toHaveBeenCalledWith(expect.objectContaining({ lazy: true }))
-    expect(printTable).toHaveBeenCalledWith(
-      expect.objectContaining({
-        rows: expect.arrayContaining([expect.objectContaining({ id: 'pi_0' })]),
-      }),
-    )
-    // Should have only 5 items due to limit
-    const call = vi.mocked(printTable).mock.calls[0][0]
-    expect(call.rows).toHaveLength(5)
-  })
-
-  test('passes filter flags to SDK', async () => {
-    mockManager.list.mockResolvedValue(asyncGenerator([]))
-
-    const program = createProgram()
-    await program.parseAsync(['payment_intents', 'list', '--status', 'succeeded'], { from: 'user' })
-
-    expect(mockManager.list).toHaveBeenCalledWith(
-      expect.objectContaining({ status: 'succeeded', lazy: true }),
-    )
-  })
-
-  test('defaults limit to 10', async () => {
-    const items = Array.from({ length: 15 }, (_, i) => ({
-      serialize: () => ({ id: `pi_${i}` }),
-    }))
-    mockManager.list.mockResolvedValue(asyncGenerator(items))
-
-    const program = createProgram()
-    await program.parseAsync(['payment_intents', 'list'], { from: 'user' })
-
-    const call = vi.mocked(printTable).mock.calls[0][0]
-    expect(call.rows).toHaveLength(10)
-  })
-
-  test('outputs JSON when --json flag is set', async () => {
-    const items = [{ serialize: () => ({ id: 'pi_0' }) }]
-    mockManager.list.mockResolvedValue(asyncGenerator(items))
-
-    const program = createProgram()
-    await program.parseAsync(['--json', 'payment_intents', 'list'], { from: 'user' })
-
-    expect(printJson).toHaveBeenCalledWith([{ id: 'pi_0' }])
-    expect(printTable).not.toHaveBeenCalled()
-  })
-
-  test.each(['abc', '0', '-5'])('exits with error when --limit is %s', async (value) => {
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('process.exit')
+      expect(mockManager.list).toHaveBeenCalledWith(expect.objectContaining({ lazy: true }))
+      expect(printTable).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rows: expect.arrayContaining([expect.objectContaining({ id: 'pi_0' })]),
+        }),
+      )
+      // Should have only 5 items due to limit
+      const call = vi.mocked(printTable).mock.calls[0][0]
+      expect(call.rows).toHaveLength(5)
     })
 
-    const program = createProgram()
-    await expect(
-      program.parseAsync(['payment_intents', 'list', '--limit', value], { from: 'user' }),
-    ).rejects.toThrow('process.exit')
+    test('passes filter flags to SDK', async () => {
+      mockManager.list.mockResolvedValue(asyncGenerator([]))
 
-    expect(error).toHaveBeenCalledWith('--limit must be a positive number')
-    expect(mockManager.list).not.toHaveBeenCalled()
-    exitSpy.mockRestore()
+      const program = createProgram()
+      await program.parseAsync(['payment_intents', 'list', '--status', 'succeeded'], {
+        from: 'user',
+      })
+
+      expect(mockManager.list).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'succeeded', lazy: true }),
+      )
+    })
+
+    test('defaults limit to 10', async () => {
+      const items = Array.from({ length: 15 }, (_, i) => ({
+        serialize: () => ({ id: `pi_${i}` }),
+      }))
+      mockManager.list.mockResolvedValue(asyncGenerator(items))
+
+      const program = createProgram()
+      await program.parseAsync(['payment_intents', 'list'], { from: 'user' })
+
+      const call = vi.mocked(printTable).mock.calls[0][0]
+      expect(call.rows).toHaveLength(10)
+    })
+  })
+
+  describe('when --json flag is set', () => {
+    test('outputs JSON instead of table', async () => {
+      const items = [{ serialize: () => ({ id: 'pi_0' }) }]
+      mockManager.list.mockResolvedValue(asyncGenerator(items))
+
+      const program = createProgram()
+      await program.parseAsync(['--json', 'payment_intents', 'list'], { from: 'user' })
+
+      expect(printJson).toHaveBeenCalledWith([{ id: 'pi_0' }])
+      expect(printTable).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when --limit is invalid', () => {
+    test.each(['abc', '0', '-5'])('exits with error when --limit is %s', async (value) => {
+      const exitSpy = mockProcessExit()
+
+      const program = createProgram()
+      await expect(
+        program.parseAsync(['payment_intents', 'list', '--limit', value], { from: 'user' }),
+      ).rejects.toThrow('process.exit')
+
+      expect(error).toHaveBeenCalledWith('--limit must be a positive number')
+      expect(mockManager.list).not.toHaveBeenCalled()
+      exitSpy.mockRestore()
+    })
   })
 })
 
 describe('factory: delete command', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
+  describe('when --yes flag skips confirmation', () => {
+    test('calls SDK delete directly', async () => {
+      mockManager.delete.mockResolvedValue('deleted')
 
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
+      const program = createProgram()
+      await program.parseAsync(['payment_intents', 'delete', 'pi_123', '--yes'], { from: 'user' })
 
-  test('calls SDK delete with confirmation skipped via --yes', async () => {
-    mockManager.delete.mockResolvedValue('deleted')
-
-    const program = createProgram()
-    await program.parseAsync(['payment_intents', 'delete', 'pi_123', '--yes'], { from: 'user' })
-
-    expect(mockManager.delete).toHaveBeenCalledWith('pi_123')
-    expect(success).toHaveBeenCalledWith(expect.stringContaining('pi_123'))
-  })
-
-  test('exits with error in non-TTY without --yes', async () => {
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('process.exit')
+      expect(mockManager.delete).toHaveBeenCalledWith('pi_123')
+      expect(success).toHaveBeenCalledWith(expect.stringContaining('pi_123'))
     })
-
-    const originalIsTTY = process.stdin.isTTY
-    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true })
-
-    const program = createProgram()
-    await expect(
-      program.parseAsync(['payment_intents', 'delete', 'pi_123'], { from: 'user' }),
-    ).rejects.toThrow('process.exit')
-
-    expect(mockManager.delete).not.toHaveBeenCalled()
-    expect(error).toHaveBeenCalledWith(expect.stringContaining('--yes'))
-
-    Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
-    exitSpy.mockRestore()
   })
 
-  test('aborts when user declines confirmation', async () => {
-    const { confirm } = await import('@inquirer/prompts')
-    vi.mocked(confirm).mockResolvedValue(false)
+  describe('when running in non-TTY without --yes', () => {
+    test('exits with error', async () => {
+      const exitSpy = mockProcessExit()
 
-    const originalIsTTY = process.stdin.isTTY
-    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+      const originalIsTTY = process.stdin.isTTY
+      Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true })
 
-    const program = createProgram()
-    await program.parseAsync(['payment_intents', 'delete', 'pi_123'], { from: 'user' })
+      const program = createProgram()
+      await expect(
+        program.parseAsync(['payment_intents', 'delete', 'pi_123'], { from: 'user' }),
+      ).rejects.toThrow('process.exit')
 
-    expect(mockManager.delete).not.toHaveBeenCalled()
-    expect(log).toHaveBeenCalledWith('Aborted.')
+      expect(mockManager.delete).not.toHaveBeenCalled()
+      expect(error).toHaveBeenCalledWith(expect.stringContaining('--yes'))
 
-    Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
+      Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
+      exitSpy.mockRestore()
+    })
+  })
+
+  describe('when user declines confirmation', () => {
+    test('aborts without calling SDK', async () => {
+      vi.mocked(confirm).mockResolvedValue(false)
+
+      const originalIsTTY = process.stdin.isTTY
+      Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+
+      const program = createProgram()
+      await program.parseAsync(['payment_intents', 'delete', 'pi_123'], { from: 'user' })
+
+      expect(mockManager.delete).not.toHaveBeenCalled()
+      expect(log).toHaveBeenCalledWith('Aborted.')
+
+      Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
+    })
   })
 })
 
 describe('factory: --jws-private-key flag', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-
-  test('adds --jws-private-key flag when resource.needsJws is true', () => {
-    const jwsResource: ResourceDef = {
-      name: 'transfers',
-      displayName: 'transfer',
-      cliCommand: 'transfers',
-      sdkMethod: 'paymentIntents',
-      sdkNamespace: 'v2',
-      verbs: ['create'],
-      needsJws: true,
-      priorityColumns: ['id'],
-      createFlags: [
-        { name: 'amount', type: 'number', required: true },
-        { name: 'currency', type: 'string', required: true },
-      ],
-      listFlags: [],
-    }
-
-    const program = createProgram(jwsResource)
-    const resourceCmd = program.commands.find((c) => c.name() === 'transfers')!
-    const createCmd = resourceCmd.commands.find((c) => c.name() === 'create')!
-    const options = createCmd.options.map((o) => o.long)
-
-    expect(options).toContain('--jws-private-key')
-  })
-
-  test('does not add --jws-private-key flag when resource.needsJws is false', () => {
-    const program = createProgram()
-    const resourceCmd = program.commands.find((c) => c.name() === 'payment_intents')!
-    const createCmd = resourceCmd.commands.find((c) => c.name() === 'create')!
-    const options = createCmd.options.map((o) => o.long)
-
-    expect(options).not.toContain('--jws-private-key')
-  })
-
-  test('passes jws key path to createClient when flag is provided', async () => {
-    const { createClient } = await import('../../lib/auth.js')
-
+  describe('when resource.needsJws is true', () => {
     const jwsResource: ResourceDef = {
       name: 'transfers',
       displayName: 'transfer',
@@ -763,25 +697,47 @@ describe('factory: --jws-private-key flag', () => {
       listFlags: [],
     }
 
-    const mockResult = { serialize: () => ({ id: 'tr_123' }) }
-    mockManager.create.mockResolvedValue(mockResult)
+    test('adds --jws-private-key flag to create command', () => {
+      const program = createProgram(jwsResource)
+      const resourceCmd = program.commands.find((c) => c.name() === 'transfers')!
+      const createCmd = resourceCmd.commands.find((c) => c.name() === 'create')!
+      const options = createCmd.options.map((o) => o.long)
 
-    const program = createProgram(jwsResource)
-    await program.parseAsync(
-      [
-        'transfers',
-        'create',
-        '--amount',
-        '10000',
-        '--currency',
-        'CLP',
-        '--jws-private-key',
-        '/path/to/key.pem',
-      ],
-      { from: 'user' },
-    )
+      expect(options).toContain('--jws-private-key')
+    })
 
-    expect(createClient).toHaveBeenCalledWith('sk_test_123', '/path/to/key.pem')
+    test('passes jws key path to createClient when flag is provided', async () => {
+      const mockResult = { serialize: () => ({ id: 'tr_123' }) }
+      mockManager.create.mockResolvedValue(mockResult)
+
+      const program = createProgram(jwsResource)
+      await program.parseAsync(
+        [
+          'transfers',
+          'create',
+          '--amount',
+          '10000',
+          '--currency',
+          'CLP',
+          '--jws-private-key',
+          '/path/to/key.pem',
+        ],
+        { from: 'user' },
+      )
+
+      expect(createClient).toHaveBeenCalledWith('sk_test_123', '/path/to/key.pem')
+    })
+  })
+
+  describe('when resource.needsJws is false', () => {
+    test('does not add --jws-private-key flag', () => {
+      const program = createProgram()
+      const resourceCmd = program.commands.find((c) => c.name() === 'payment_intents')!
+      const createCmd = resourceCmd.commands.find((c) => c.name() === 'create')!
+      const options = createCmd.options.map((o) => o.long)
+
+      expect(options).not.toContain('--jws-private-key')
+    })
   })
 })
 
@@ -801,16 +757,14 @@ describe('factory: v2 namespace', () => {
     listFlags: [],
   }
 
-  beforeEach(async () => {
-    vi.clearAllMocks()
-
+  const setupV2Client = () => {
     const v2Client = { v2: { transfers: v2Manager } }
-    const { createClient } = await import('../../lib/auth.js')
     vi.mocked(createClient).mockReturnValue(v2Client as unknown as ReturnType<typeof createClient>)
-  })
+  }
 
   describe('when registered directly on a program', () => {
     test('routes to the v2 SDK namespace', async () => {
+      setupV2Client()
       v2Manager.list.mockResolvedValue(asyncGenerator([]))
 
       const program = createProgram(v2Resource)
@@ -831,6 +785,7 @@ describe('factory: v2 namespace', () => {
     }
 
     test('routes to the v2 SDK namespace', async () => {
+      setupV2Client()
       v2Manager.list.mockResolvedValue(asyncGenerator([]))
 
       const program = createV2Program()
@@ -840,6 +795,7 @@ describe('factory: v2 namespace', () => {
     })
 
     test('resolves root --json flag through nested commands', async () => {
+      setupV2Client()
       v2Manager.list.mockResolvedValue(asyncGenerator([{ serialize: () => ({ id: 'tr_1' }) }]))
 
       const program = createV2Program()

--- a/src/resources/__tests__/factory.test.ts
+++ b/src/resources/__tests__/factory.test.ts
@@ -2,7 +2,7 @@ import type { ResourceDef } from '../../types.js'
 import { readFileSync } from 'node:fs'
 import { confirm } from '@inquirer/prompts'
 import { Command } from 'commander'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { createClient, resolveAuth } from '../../lib/auth.js'
 import { error, log, printDetail, printJson, printTable, success } from '../../lib/output.js'
 import { registerResourceCommands } from '../factory.js'
@@ -63,7 +63,7 @@ const testResource: ResourceDef = {
   verbs: ['create', 'get', 'list', 'delete'],
   priorityColumns: ['id', 'amount', 'currency', 'status', 'created_at'],
   createFlags: [
-    { name: 'amount', type: 'number', required: true, description: 'Amount' },
+    { name: 'amount', type: 'integer', required: true, description: 'Amount' },
     { name: 'currency', type: 'string', required: true, description: 'Currency code' },
     { name: 'customer-email', type: 'string', description: 'Customer email' },
   ],
@@ -180,7 +180,7 @@ describe('factory: create command', () => {
         verbs: ['create'],
         priorityColumns: ['id'],
         createFlags: [
-          { name: 'amount', type: 'number', required: true },
+          { name: 'amount', type: 'integer', required: true },
           { name: 'currency', type: 'string', required: true },
           {
             name: 'recipient-account-type',
@@ -249,22 +249,80 @@ describe('factory: create command', () => {
     })
   })
 
-  describe('when required flags are missing', () => {
-    test('exits with error listing missing flags', async () => {
-      const exitSpy = mockProcessExit()
+  describe('when number flag value is invalid', () => {
+    let exitSpy: ReturnType<typeof vi.spyOn>
 
+    beforeEach(() => {
+      exitSpy = mockProcessExit()
+    })
+
+    afterEach(() => {
+      exitSpy.mockRestore()
+    })
+
+    test('exits with error when value is not a number', async () => {
+      const program = createProgram()
+      await expect(
+        program.parseAsync(['payment_intents', 'create', '--amount', 'abc', '--currency', 'CLP'], {
+          from: 'user',
+        }),
+      ).rejects.toThrow('process.exit')
+
+      expect(error).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid value 'abc' for flag --amount: expected a number"),
+      )
+      expect(mockManager.create).not.toHaveBeenCalled()
+    })
+
+    test('exits with error when value is a decimal', async () => {
+      const program = createProgram()
+      await expect(
+        program.parseAsync(['payment_intents', 'create', '--amount', '1.5', '--currency', 'CLP'], {
+          from: 'user',
+        }),
+      ).rejects.toThrow('process.exit')
+
+      expect(error).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid value '1.5' for flag --amount: expected an integer"),
+      )
+      expect(mockManager.create).not.toHaveBeenCalled()
+    })
+
+    test('accepts valid integer values', async () => {
+      const mockResult = { serialize: () => ({ id: 'pi_123', amount: 10000 }) }
+      mockManager.create.mockResolvedValue(mockResult)
+
+      const program = createProgram()
+      await program.parseAsync(
+        ['payment_intents', 'create', '--amount', '10000', '--currency', 'CLP'],
+        { from: 'user' },
+      )
+
+      expect(mockManager.create).toHaveBeenCalledWith({ amount: 10000, currency: 'CLP' })
+    })
+  })
+
+  describe('when required flags are missing', () => {
+    let exitSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+      exitSpy = mockProcessExit()
+    })
+
+    afterEach(() => {
+      exitSpy.mockRestore()
+    })
+
+    test('exits with error listing missing flags', async () => {
       const program = createProgram()
       await expect(
         program.parseAsync(['payment_intents', 'create', '--currency', 'CLP'], { from: 'user' }),
       ).rejects.toThrow('process.exit')
 
       expect(error).toHaveBeenCalledWith(expect.stringContaining('--amount'))
-      exitSpy.mockRestore()
     })
 
     test('shows v2 prefix in usage hint for v2 resources', async () => {
-      const exitSpy = mockProcessExit()
-
       const v2Resource: ResourceDef = {
         ...testResource,
         name: 'transfers',
@@ -278,7 +336,6 @@ describe('factory: create command', () => {
       ).rejects.toThrow('process.exit')
 
       expect(log).toHaveBeenCalledWith(expect.stringContaining('fintoc v2 transfers create'))
-      exitSpy.mockRestore()
     })
   })
 })
@@ -385,7 +442,7 @@ describe('factory: create --from-json', () => {
         verbs: ['create'],
         priorityColumns: ['id'],
         createFlags: [
-          { name: 'amount', type: 'number', required: true },
+          { name: 'amount', type: 'integer', required: true },
           { name: 'currency', type: 'string', required: true },
           {
             name: 'recipient-account-type',
@@ -449,6 +506,10 @@ describe('factory: create --from-json', () => {
       exitSpy = mockProcessExit()
     })
 
+    afterEach(() => {
+      exitSpy.mockRestore()
+    })
+
     test('exits with error on invalid JSON', async () => {
       vi.mocked(readFileSync).mockReturnValue('not valid json')
 
@@ -460,7 +521,6 @@ describe('factory: create --from-json', () => {
       ).rejects.toThrow('process.exit')
 
       expect(error).toHaveBeenCalledWith(expect.stringContaining('invalid JSON'))
-      exitSpy.mockRestore()
     })
 
     test('exits with error when file does not exist', async () => {
@@ -482,7 +542,6 @@ describe('factory: create --from-json', () => {
       ).rejects.toThrow('process.exit')
 
       expect(error).toHaveBeenCalledWith("--from-json: file 'missing.json' not found")
-      exitSpy.mockRestore()
     })
 
     test('exits with error when stdin is a TTY', async () => {
@@ -504,7 +563,6 @@ describe('factory: create --from-json', () => {
         value: originalIsTTY,
         configurable: true,
       })
-      exitSpy.mockRestore()
     })
 
     test('exits with error when JSON is not an object', async () => {
@@ -518,7 +576,6 @@ describe('factory: create --from-json', () => {
       ).rejects.toThrow('process.exit')
 
       expect(error).toHaveBeenCalledWith('--from-json must contain a JSON object')
-      exitSpy.mockRestore()
     })
   })
 })
@@ -613,9 +670,17 @@ describe('factory: list command', () => {
   })
 
   describe('when --limit is invalid', () => {
-    test.each(['abc', '0', '-5'])('exits with error when --limit is %s', async (value) => {
-      const exitSpy = mockProcessExit()
+    let exitSpy: ReturnType<typeof vi.spyOn>
 
+    beforeEach(() => {
+      exitSpy = mockProcessExit()
+    })
+
+    afterEach(() => {
+      exitSpy.mockRestore()
+    })
+
+    test.each(['abc', '0', '-5'])('exits with error when --limit is %s', async (value) => {
       const program = createProgram()
       await expect(
         program.parseAsync(['payment_intents', 'list', '--limit', value], { from: 'user' }),
@@ -623,7 +688,6 @@ describe('factory: list command', () => {
 
       expect(error).toHaveBeenCalledWith('--limit must be a positive number')
       expect(mockManager.list).not.toHaveBeenCalled()
-      exitSpy.mockRestore()
     })
   })
 })
@@ -642,12 +706,21 @@ describe('factory: delete command', () => {
   })
 
   describe('when running in non-TTY without --yes', () => {
-    test('exits with error', async () => {
-      const exitSpy = mockProcessExit()
+    let exitSpy: ReturnType<typeof vi.spyOn>
+    let originalIsTTY: boolean | undefined
 
-      const originalIsTTY = process.stdin.isTTY
+    beforeEach(() => {
+      exitSpy = mockProcessExit()
+      originalIsTTY = process.stdin.isTTY
       Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true })
+    })
 
+    afterEach(() => {
+      Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
+      exitSpy.mockRestore()
+    })
+
+    test('exits with error', async () => {
       const program = createProgram()
       await expect(
         program.parseAsync(['payment_intents', 'delete', 'pi_123'], { from: 'user' }),
@@ -655,9 +728,6 @@ describe('factory: delete command', () => {
 
       expect(mockManager.delete).not.toHaveBeenCalled()
       expect(error).toHaveBeenCalledWith(expect.stringContaining('--yes'))
-
-      Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
-      exitSpy.mockRestore()
     })
   })
 
@@ -691,7 +761,7 @@ describe('factory: --jws-private-key flag', () => {
       needsJws: true,
       priorityColumns: ['id'],
       createFlags: [
-        { name: 'amount', type: 'number', required: true },
+        { name: 'amount', type: 'integer', required: true },
         { name: 'currency', type: 'string', required: true },
       ],
       listFlags: [],

--- a/src/resources/__tests__/registry.test.ts
+++ b/src/resources/__tests__/registry.test.ts
@@ -3,69 +3,65 @@ import { describe, expect, test } from 'vitest'
 import { resources, v1Resources, v2Resources } from '../registry.js'
 
 describe('resource registry', () => {
-  test('contains all 9 resources', () => {
-    expect(resources).toHaveLength(9)
+  describe('schema validation', () => {
+    test('contains all 9 resources', () => {
+      expect(resources).toHaveLength(9)
 
-    const names = resources.map((r) => r.name)
-    expect(names).toEqual([
-      'payment_intents',
-      'transfers',
-      'accounts',
-      'webhook_endpoints',
-      'charges',
-      'subscriptions',
-      'links',
-      'checkout_sessions',
-      'api_keys',
-    ])
-  })
+      const names = resources.map((r) => r.name)
+      expect(names).toEqual([
+        'payment_intents',
+        'transfers',
+        'accounts',
+        'webhook_endpoints',
+        'charges',
+        'subscriptions',
+        'links',
+        'checkout_sessions',
+        'api_keys',
+      ])
+    })
 
-  test('every resource has required fields', () => {
-    for (const resource of resources) {
-      expect(resource.name).toBeTruthy()
-      expect(resource.cliCommand).toBeTruthy()
-      expect(resource.sdkMethod).toBeTruthy()
-      expect(['v1', 'v2']).toContain(resource.sdkNamespace)
-      expect(resource.verbs.length).toBeGreaterThan(0)
-      expect(resource.priorityColumns.length).toBeGreaterThanOrEqual(1)
-      expect(resource.priorityColumns.length).toBeLessThanOrEqual(6)
-    }
-  })
+    test('every resource has required fields', () => {
+      for (const resource of resources) {
+        expect(resource.name).toBeTruthy()
+        expect(resource.cliCommand).toBeTruthy()
+        expect(resource.sdkMethod).toBeTruthy()
+        expect(['v1', 'v2']).toContain(resource.sdkNamespace)
+        expect(resource.verbs.length).toBeGreaterThan(0)
+        expect(resource.priorityColumns.length).toBeGreaterThanOrEqual(1)
+        expect(resource.priorityColumns.length).toBeLessThanOrEqual(6)
+      }
+    })
 
-  test('verbs are valid', () => {
-    const validVerbs = new Set(['create', 'get', 'list', 'delete', 'expire'])
-    resources.forEach((resource) => {
-      resource.verbs.forEach((verb) => {
-        expect(validVerbs.has(verb)).toBe(true)
+    test('verbs are valid', () => {
+      const validVerbs = new Set(['create', 'get', 'list', 'delete', 'expire'])
+      resources.forEach((resource) => {
+        resource.verbs.forEach((verb) => {
+          expect(validVerbs.has(verb)).toBe(true)
+        })
       })
     })
-  })
 
-  test('resources with create verb have createFlags', () => {
-    resources
-      .filter((resource) => resource.verbs.includes('create'))
-      .forEach((resource) => {
-        expect(resource.createFlags).toBeDefined()
-        expect(resource.createFlags!.length).toBeGreaterThan(0)
-      })
-  })
+    test('resources with create verb have createFlags', () => {
+      resources
+        .filter((resource) => resource.verbs.includes('create'))
+        .forEach((resource) => {
+          expect(resource.createFlags).toBeDefined()
+          expect(resource.createFlags!.length).toBeGreaterThan(0)
+        })
+    })
 
-  test('createFlags with required=true exist for resources that need them', () => {
-    const checkoutSessions = resources.find((r) => r.name === 'checkout_sessions')!
-    const requiredFlags = checkoutSessions.createFlags!.filter((f) => f.required)
-    expect(requiredFlags.map((f) => f.name)).toEqual(['amount', 'currency'])
-  })
-
-  test('all flag types are valid', () => {
-    const validTypes = new Set(['string', 'number', 'boolean', 'string[]'])
-    for (const resource of resources) {
-      for (const flag of resource.createFlags ?? []) {
-        expect(validTypes.has(flag.type)).toBe(true)
+    test('all flag types are valid', () => {
+      const validTypes = new Set(['string', 'number', 'boolean', 'string[]'])
+      for (const resource of resources) {
+        for (const flag of resource.createFlags ?? []) {
+          expect(validTypes.has(flag.type)).toBe(true)
+        }
+        for (const flag of resource.listFlags ?? []) {
+          expect(validTypes.has(flag.type)).toBe(true)
+        }
       }
-      for (const flag of resource.listFlags ?? []) {
-        expect(validTypes.has(flag.type)).toBe(true)
-      }
-    }
+    })
   })
 
   describe('v2 resources', () => {
@@ -118,8 +114,14 @@ describe('resource registry', () => {
     })
   })
 
-  describe('transfers create flags', () => {
-    test('requires amount, currency, account-id, counterparty-account-number, and counterparty-institution-id', () => {
+  describe('resource-specific flags', () => {
+    test('checkout_sessions requires amount and currency', () => {
+      const checkoutSessions = resources.find((r) => r.name === 'checkout_sessions')!
+      const requiredFlags = checkoutSessions.createFlags!.filter((f) => f.required)
+      expect(requiredFlags.map((f) => f.name)).toEqual(['amount', 'currency'])
+    })
+
+    test('transfers requires amount, currency, account-id, counterparty-account-number, and counterparty-institution-id', () => {
       const transfers = resources.find((r) => r.name === 'transfers')!
       const requiredFlags = transfers.createFlags!.filter((f) => f.required)
       expect(requiredFlags.map((f) => f.name)).toEqual([
@@ -130,16 +132,14 @@ describe('resource registry', () => {
         'counterparty-institution-id',
       ])
     })
-  })
 
-  describe('webhook_endpoints create flags', () => {
-    test('requires url and enabled-events', () => {
+    test('webhook_endpoints requires url and enabled-events', () => {
       const webhooks = resources.find((r) => r.name === 'webhook_endpoints')!
       const requiredFlags = webhooks.createFlags!.filter((f) => f.required)
       expect(requiredFlags.map((f) => f.name)).toEqual(['url', 'enabled-events'])
     })
 
-    test('enabled-events is string[] type', () => {
+    test('webhook_endpoints enabled-events is string[] type', () => {
       const webhooks = resources.find((r) => r.name === 'webhook_endpoints')!
       const eventsFlag = webhooks.createFlags!.find((f) => f.name === 'enabled-events')!
       expect(eventsFlag.type).toBe('string[]')

--- a/src/resources/__tests__/registry.test.ts
+++ b/src/resources/__tests__/registry.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, test } from 'vitest'
-
 import { resources, v1Resources, v2Resources } from '../registry.js'
 
 describe('resource registry', () => {

--- a/src/resources/__tests__/registry.test.ts
+++ b/src/resources/__tests__/registry.test.ts
@@ -52,7 +52,7 @@ describe('resource registry', () => {
     })
 
     test('all flag types are valid', () => {
-      const validTypes = new Set(['string', 'number', 'boolean', 'string[]'])
+      const validTypes = new Set(['string', 'integer', 'boolean', 'string[]'])
       for (const resource of resources) {
         for (const flag of resource.createFlags ?? []) {
           expect(validTypes.has(flag.type)).toBe(true)

--- a/src/resources/factory.ts
+++ b/src/resources/factory.ts
@@ -42,8 +42,15 @@ const getManager = (client: Fintoc, resource: ResourceDef) => {
 
 // Parse flag value according to its type
 const parseFlagValue = (value: string, flag: FlagDef) => {
-  if (flag.type === 'number') {
-    return Number(value)
+  if (flag.type === 'integer') {
+    const num = Number(value)
+    if (Number.isNaN(num)) {
+      throw new TypeError(`Invalid value '${value}' for flag --${flag.name}: expected a number`)
+    }
+    if (!Number.isInteger(num)) {
+      throw new TypeError(`Invalid value '${value}' for flag --${flag.name}: expected an integer`)
+    }
+    return num
   }
   if (flag.type === 'boolean') {
     return value === 'true'

--- a/src/resources/factory.ts
+++ b/src/resources/factory.ts
@@ -45,7 +45,7 @@ const parseFlagValue = (value: string, flag: FlagDef) => {
   if (flag.type === 'integer') {
     const num = Number(value)
     if (Number.isNaN(num)) {
-      throw new TypeError(`Invalid value '${value}' for flag --${flag.name}: expected a number`)
+      throw new TypeError(`Invalid value '${value}' for flag --${flag.name}: expected an integer`)
     }
     if (!Number.isInteger(num)) {
       throw new TypeError(`Invalid value '${value}' for flag --${flag.name}: expected an integer`)

--- a/src/resources/registry.ts
+++ b/src/resources/registry.ts
@@ -39,7 +39,7 @@ export const resources: ResourceDef[] = [
     createFlags: [
       {
         name: 'amount',
-        type: 'number',
+        type: 'integer',
         required: true,
         description: 'Amount in smallest currency unit',
       },
@@ -158,7 +158,7 @@ export const resources: ResourceDef[] = [
     createFlags: [
       {
         name: 'amount',
-        type: 'number',
+        type: 'integer',
         required: true,
         description: 'Amount in smallest currency unit',
       },
@@ -246,7 +246,7 @@ export const resources: ResourceDef[] = [
     createFlags: [
       {
         name: 'amount',
-        type: 'number',
+        type: 'integer',
         required: true,
         description: 'Amount to pay in smallest currency unit (must be > 0 and < 7000000)',
       },

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ export type FintocConfig = {
 
 export type Verb = 'create' | 'get' | 'list' | 'delete' | 'expire'
 
-export type FlagType = 'string' | 'number' | 'boolean' | 'string[]'
+export type FlagType = 'string' | 'integer' | 'boolean' | 'string[]'
 
 export type FlagDef = {
   name: string


### PR DESCRIPTION
## Contexto

La CLI no validaba localmente `--api-key ""` ni valores no numéricos en flags de tipo número, dejando que errores poco claros llegaran desde el SDK/API.

## Que hay de nuevo?

- [x] Validación de `--api-key` vacío/whitespace en `resolveAuth`
- [x] Flag type `number` → `integer` con validación estricta (rechaza decimales y NaN)
- [x] Extracción de magic values a constantes y reestructuración de tests

## Tests

- [x] Tests unitarios para ambas validaciones

<sup>*Created with Claude Code `/create-pr` command*</sup>