### PR TITLE
[ONB-1853] QA fixes para CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ fintoc payment_intents list --json
 fintoc v2 accounts get acc_test_abc123 --json
 ```
 
+Use `--no-color` to disable colored output.
+
 ### Discovering flags
 
 Each command documents its available flags via `--help`:

--- a/src/commands/__tests__/config.test.ts
+++ b/src/commands/__tests__/config.test.ts
@@ -81,7 +81,7 @@ describe('config command', () => {
           organization: 'Acme Corp',
           mode: 'test',
           api_version: '2023-03-15',
-          source: 'config file',
+          source: 'config',
           api_reachable: true,
         }),
       )

--- a/src/commands/__tests__/config.test.ts
+++ b/src/commands/__tests__/config.test.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { resolveAuth, whoami } from '../../lib/auth.js'
 import { readConfig, writeConfig } from '../../lib/config.js'
-import { error, log, success, warn } from '../../lib/output.js'
+import { error, hint, log, printJson, success, warn } from '../../lib/output.js'
 import { configCommand } from '../config.js'
 
 vi.mock('../../lib/auth.js', () => ({
@@ -19,14 +19,17 @@ vi.mock('../../lib/config.js', () => ({
 
 vi.mock('../../lib/output.js', () => ({
   log: vi.fn(),
+  hint: vi.fn(),
   success: vi.fn(),
   error: vi.fn(),
   warn: vi.fn(),
+  printJson: vi.fn(),
 }))
 
 const createProgram = () => {
   const program = new Command()
   program.exitOverride()
+  program.option('--json', 'Output as JSON')
   configCommand(program)
   return program
 }
@@ -57,6 +60,69 @@ describe('config command', () => {
     })
   })
 
+  describe('when --json is passed', () => {
+    test('outputs JSON when authenticated', async () => {
+      vi.mocked(resolveAuth).mockReturnValue({
+        secretKey: 'sk_test_abc123',
+        source: 'config',
+      })
+      vi.mocked(whoami).mockResolvedValue({
+        organizationName: 'Acme Corp',
+        mode: 'test',
+        apiVersion: '2023-03-15',
+      })
+
+      const program = createProgram()
+      await program.parseAsync(['--json', 'config'], { from: 'user' })
+
+      expect(printJson).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authenticated: true,
+          organization: 'Acme Corp',
+          mode: 'test',
+          api_version: '2023-03-15',
+          source: 'config file',
+          api_reachable: true,
+        }),
+      )
+      expect(log).not.toHaveBeenCalled()
+    })
+
+    test('outputs JSON with nulls when API is unreachable', async () => {
+      vi.mocked(resolveAuth).mockReturnValue({
+        secretKey: 'sk_test_abc123',
+        source: 'config',
+      })
+      vi.mocked(whoami).mockRejectedValue(new Error('Network error'))
+
+      const program = createProgram()
+      await program.parseAsync(['--json', 'config'], { from: 'user' })
+
+      expect(printJson).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authenticated: true,
+          organization: null,
+          mode: null,
+          api_version: null,
+          api_reachable: false,
+        }),
+      )
+      expect(warn).not.toHaveBeenCalled()
+    })
+
+    test('outputs JSON when not authenticated', async () => {
+      vi.mocked(resolveAuth).mockImplementation(() => {
+        throw new Error('No API key found')
+      })
+
+      const program = createProgram()
+      await program.parseAsync(['--json', 'config'], { from: 'user' })
+
+      expect(printJson).toHaveBeenCalledWith(expect.objectContaining({ authenticated: false }))
+      expect(log).not.toHaveBeenCalled()
+    })
+  })
+
   describe('when not authenticated', () => {
     test('shows not authenticated message', async () => {
       vi.mocked(resolveAuth).mockImplementation(() => {
@@ -66,7 +132,7 @@ describe('config command', () => {
       const program = createProgram()
       await program.parseAsync(['config'], { from: 'user' })
 
-      expect(log).toHaveBeenCalledWith(expect.stringContaining('Not authenticated'))
+      expect(hint).toHaveBeenCalledWith(expect.stringContaining('Not authenticated'))
     })
   })
 
@@ -82,7 +148,7 @@ describe('config command', () => {
       await program.parseAsync(['config'], { from: 'user' })
 
       expect(warn).toHaveBeenCalledWith(expect.stringContaining('Unable to reach Fintoc API'))
-      expect(log).toHaveBeenCalledWith(expect.stringContaining('(unknown)'))
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('  -'))
       expect(log).toHaveBeenCalledWith(expect.stringContaining('env var'))
     })
   })

--- a/src/commands/__tests__/doctor.test.ts
+++ b/src/commands/__tests__/doctor.test.ts
@@ -4,7 +4,7 @@ import { Command } from 'commander'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { resolveAuth, whoami } from '../../lib/auth.js'
 import { readConfig } from '../../lib/config.js'
-import { error, info, log, success, warn } from '../../lib/output.js'
+import { error, hint, info, success, warn } from '../../lib/output.js'
 import { doctorCommand } from '../doctor.js'
 
 vi.mock('node:child_process', () => ({
@@ -29,6 +29,7 @@ vi.mock('../../lib/config.js', () => ({
 
 vi.mock('../../lib/output.js', () => ({
   log: vi.fn(),
+  hint: vi.fn(),
   success: vi.fn(),
   error: vi.fn(),
   warn: vi.fn(),
@@ -106,7 +107,7 @@ describe('doctor command', () => {
       await program.parseAsync(['doctor'], { from: 'user' })
 
       expect(success).toHaveBeenCalledWith(expect.stringContaining('CLI version'))
-      expect(log).toHaveBeenCalledWith(expect.stringContaining('could not check for updates'))
+      expect(hint).toHaveBeenCalledWith(expect.stringContaining('could not check for updates'))
     })
   })
 
@@ -122,7 +123,7 @@ describe('doctor command', () => {
       await program.parseAsync(['doctor'], { from: 'user' })
 
       expect(error).toHaveBeenCalledWith(expect.stringContaining('API key'))
-      expect(log).toHaveBeenCalledWith(expect.stringContaining('skipped'))
+      expect(hint).toHaveBeenCalledWith(expect.stringContaining('skipped'))
       expect(whoami).not.toHaveBeenCalled()
     })
   })

--- a/src/commands/__tests__/login.test.ts
+++ b/src/commands/__tests__/login.test.ts
@@ -19,6 +19,7 @@ vi.mock('../../lib/config.js', () => ({
 
 vi.mock('../../lib/output.js', () => ({
   log: vi.fn(),
+  hint: vi.fn(),
   success: vi.fn(),
   error: vi.fn(),
   warn: vi.fn(),

--- a/src/commands/__tests__/logout.test.ts
+++ b/src/commands/__tests__/logout.test.ts
@@ -11,6 +11,7 @@ vi.mock('../../lib/config.js', () => ({
 
 vi.mock('../../lib/output.js', () => ({
   log: vi.fn(),
+  hint: vi.fn(),
   success: vi.fn(),
   error: vi.fn(),
   warn: vi.fn(),

--- a/src/commands/__tests__/open.test.ts
+++ b/src/commands/__tests__/open.test.ts
@@ -21,6 +21,19 @@ const createProgram = () => {
 }
 
 describe('open command', () => {
+  describe('when called without subcommand', () => {
+    test('shows help instead of erroring', async () => {
+      const program = createProgram()
+
+      await expect(program.parseAsync(['open'], { from: 'user' })).rejects.toMatchObject({
+        exitCode: 0,
+        code: 'commander.help',
+      })
+
+      expect(exec).not.toHaveBeenCalled()
+    })
+  })
+
   let originalPlatform: string
 
   beforeEach(() => {

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -2,7 +2,7 @@ import type { Command } from 'commander'
 import type { FintocConfig } from '../types.js'
 import { maskKey, resolveAuth, whoami } from '../lib/auth.js'
 import { CONFIG_PATH, readConfig, writeConfig } from '../lib/config.js'
-import { error, log, success, warn } from '../lib/output.js'
+import { error, hint, log, printJson, success, warn } from '../lib/output.js'
 
 const ALLOWED_KEYS: readonly string[] = [
   'secret_key',
@@ -13,52 +13,73 @@ const ALLOWED_KEYS: readonly string[] = [
 const isConfigKey = (key: string): key is keyof FintocConfig => ALLOWED_KEYS.includes(key)
 
 export const configCommand = (program: Command) => {
-  const configCmd = program
-    .command('config')
-    .description('Show or update CLI configuration')
-    .action(async (_opts: unknown, cmd: Command) => {
-      let secretKey: string
-      let source: string
+  const configCmd = program.command('config').description('Show or update CLI configuration')
+  configCmd.configureHelp({ showGlobalOptions: true })
+  configCmd.action(async (_opts: unknown, cmd: Command) => {
+    let secretKey: string
+    let source: string
 
-      const sourceLabels = {
-        flag: 'inline flag (--api-key)',
-        env: 'env var (FINTOC_SECRET_KEY)',
-        config: 'config file',
-      } satisfies Record<string, string>
+    const sourceLabels = {
+      flag: 'inline flag (--api-key)',
+      env: 'env var (FINTOC_SECRET_KEY)',
+      config: 'config file',
+    } satisfies Record<string, string>
 
-      const rootOpts = cmd.parent!.opts<{ apiKey?: string }>()
+    const rootOpts = cmd.parent!.opts<{ apiKey?: string; json?: boolean }>()
 
-      try {
-        const auth = resolveAuth(rootOpts)
-        secretKey = auth.secretKey
-        source = sourceLabels[auth.source]
-      } catch {
-        log('Not authenticated. Run `fintoc login` to get started.')
-        log('')
-        log(`  Config path:  ${CONFIG_PATH}`)
+    try {
+      const auth = resolveAuth(rootOpts)
+      secretKey = auth.secretKey
+      source = sourceLabels[auth.source]
+    } catch {
+      if (rootOpts.json) {
+        printJson({ authenticated: false, config_path: CONFIG_PATH })
         return
       }
+      hint('Not authenticated. Run `fintoc login` to get started.')
+      hint('')
+      hint(`  Config path:  ${CONFIG_PATH}`)
+      return
+    }
 
-      let orgName = '(unknown)'
-      let mode = '(unknown)'
-      let apiVersion = '(unknown)'
+    let orgName: string | null = null
+    let mode: string | null = null
+    let apiVersion: string | null = null
+    let apiReachable = true
 
-      try {
-        const info = await whoami(secretKey)
-        orgName = info.organizationName
-        mode = info.mode
-        apiVersion = info.apiVersion
-      } catch {
+    try {
+      const info = await whoami(secretKey)
+      orgName = info.organizationName
+      mode = info.mode
+      apiVersion = info.apiVersion
+    } catch {
+      apiReachable = false
+      if (!rootOpts.json) {
         warn('Unable to reach Fintoc API — showing cached config')
       }
+    }
 
-      log(`  Organization:  ${orgName}`)
-      log(`  Mode:          ${mode}`)
-      log(`  Secret key:    ${maskKey(secretKey)}`)
-      log(`  API version:   ${apiVersion}`)
-      log(`  Config path:   ${CONFIG_PATH}`)
-      log(`  Source:        ${source}`)
-    })
+    if (rootOpts.json) {
+      printJson({
+        authenticated: true,
+        organization: orgName,
+        mode,
+        secret_key: maskKey(secretKey),
+        api_version: apiVersion,
+        config_path: CONFIG_PATH,
+        source,
+        api_reachable: apiReachable,
+      })
+      return
+    }
+
+    log(`  Organization:  ${orgName ?? '-'}`)
+    log(`  Mode:          ${mode ?? '-'}`)
+    log(`  Secret key:    ${maskKey(secretKey)}`)
+    log(`  API version:   ${apiVersion ?? '-'}`)
+    log(`  Config path:   ${CONFIG_PATH}`)
+    log(`  Source:        ${source}`)
+  })
 
   configCmd
     .command('set <key> <value>')
@@ -66,9 +87,9 @@ export const configCommand = (program: Command) => {
     .action((key: string, value: string) => {
       if (!isConfigKey(key)) {
         error(`Unknown config key: '${key}'`)
-        log('')
-        log(`  Allowed keys: ${ALLOWED_KEYS.join(', ')}`)
-        log(`  Example: fintoc config set jws_private_key /path/to/key.pem`)
+        hint('')
+        hint(`  Allowed keys: ${ALLOWED_KEYS.join(', ')}`)
+        hint(`  Example: fintoc config set jws_private_key /path/to/key.pem`)
         process.exit(1)
       }
 
@@ -87,6 +108,6 @@ export const configCommand = (program: Command) => {
       writeConfig(config)
 
       success(`Config updated: ${key}`)
-      log(`  Saved to ${CONFIG_PATH}`)
+      hint(`  Saved to ${CONFIG_PATH}`)
     })
 }

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -17,7 +17,7 @@ export const configCommand = (program: Command) => {
   configCmd.configureHelp({ showGlobalOptions: true })
   configCmd.action(async (_opts: unknown, cmd: Command) => {
     let secretKey: string
-    let source: string
+    let source: 'flag' | 'env' | 'config'
 
     const sourceLabels = {
       flag: 'inline flag (--api-key)',
@@ -30,7 +30,7 @@ export const configCommand = (program: Command) => {
     try {
       const auth = resolveAuth(rootOpts)
       secretKey = auth.secretKey
-      source = sourceLabels[auth.source]
+      source = auth.source
     } catch {
       if (rootOpts.json) {
         printJson({ authenticated: false, config_path: CONFIG_PATH })
@@ -78,7 +78,7 @@ export const configCommand = (program: Command) => {
     log(`  Secret key:    ${maskKey(secretKey)}`)
     log(`  API version:   ${apiVersion ?? '-'}`)
     log(`  Config path:   ${CONFIG_PATH}`)
-    log(`  Source:        ${source}`)
+    log(`  Source:        ${sourceLabels[source]}`)
   })
 
   configCmd

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,7 +1,6 @@
 import type { Command } from 'commander'
 import { execSync } from 'node:child_process'
 import { existsSync, statSync } from 'node:fs'
-
 import { maskKey, resolveAuth, whoami } from '../lib/auth.js'
 import { CONFIG_PATH, readConfig } from '../lib/config.js'
 import {
@@ -10,7 +9,7 @@ import {
   NPM_CHECK_TIMEOUT_MS,
   NPM_PACKAGE_NAME,
 } from '../lib/constants.js'
-import { error, info, log, success, warn } from '../lib/output.js'
+import { error, hint, info, success, warn } from '../lib/output.js'
 import { getCliVersion } from '../lib/version.js'
 
 const checkCliVersion = () => {
@@ -29,7 +28,7 @@ const checkCliVersion = () => {
     }
   } catch {
     success(`CLI version         ${currentVersion}`)
-    log('                    (could not check for updates)')
+    hint('                    (could not check for updates)')
   }
 }
 
@@ -62,7 +61,7 @@ const checkApiKey = (options?: { apiKey?: string }) => {
     return auth
   } catch {
     error('API key             not configured')
-    log('                    Run `fintoc login` or set FINTOC_SECRET_KEY')
+    hint('                    Run `fintoc login` or set FINTOC_SECRET_KEY')
     return null
   }
 }
@@ -74,7 +73,7 @@ const checkConnectivity = async (secretKey: string) => {
     success(`Organization        ${info.organizationName} (${info.mode} mode)`)
   } catch {
     error(`Connectivity        could not reach ${API_HOST}`)
-    log('                    Check your internet connection and API key')
+    hint('                    Check your internet connection and API key')
   }
 }
 
@@ -94,25 +93,24 @@ const checkJwsKey = () => {
 }
 
 export const doctorCommand = (program: Command) => {
-  program
-    .command('doctor')
-    .description('Check CLI setup and connectivity')
-    .action(async (_opts: unknown, cmd: Command) => {
-      const rootOpts = cmd.parent!.opts<{ apiKey?: string }>()
-      log('')
-      checkCliVersion()
+  const cmd = program.command('doctor').description('Check CLI setup and connectivity')
+  cmd.configureHelp({ showGlobalOptions: true })
+  cmd.action(async (_opts: unknown, actionCmd: Command) => {
+    const rootOpts = actionCmd.parent!.opts<{ apiKey?: string }>()
+    hint('')
+    checkCliVersion()
 
-      const auth = checkApiKey(rootOpts)
-      checkConfigFile(auth?.source)
+    const auth = checkApiKey(rootOpts)
+    checkConfigFile(auth?.source)
 
-      if (auth) {
-        await checkConnectivity(auth.secretKey)
-      } else {
-        log('  ⏭ Connectivity     skipped (no API key)')
-        log('  ⏭ Organization     skipped (no API key)')
-      }
+    if (auth) {
+      await checkConnectivity(auth.secretKey)
+    } else {
+      hint('  ⏭ Connectivity     skipped (no API key)')
+      hint('  ⏭ Organization     skipped (no API key)')
+    }
 
-      checkJwsKey()
-      log('')
-    })
+    checkJwsKey()
+    hint('')
+  })
 }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -5,46 +5,45 @@ import { password } from '@inquirer/prompts'
 import { whoami } from '../lib/auth.js'
 import { CONFIG_PATH, readConfig, writeConfig } from '../lib/config.js'
 import { handleError } from '../lib/errors.js'
-import { error, log, success } from '../lib/output.js'
+import { error, hint, success } from '../lib/output.js'
 
 export const loginCommand = (program: Command) => {
-  program
-    .command('login')
-    .description('Authenticate with your Fintoc API key')
-    .action(async (_opts: unknown, actionCmd: Command) => {
-      let secretKey: string
+  const cmd = program.command('login').description('Authenticate with your Fintoc API key')
+  cmd.configureHelp({ showGlobalOptions: true })
+  cmd.action(async (_opts: unknown, actionCmd: Command) => {
+    let secretKey: string
 
-      const rootApiKey = actionCmd.parent?.opts().apiKey as string | undefined
-      if (rootApiKey) {
-        secretKey = rootApiKey
-      } else if (process.stdin.isTTY) {
-        secretKey = await password({ message: 'Enter your Fintoc secret key:' })
-      } else {
-        error('Non-interactive terminal detected. Pass the key via flag:')
-        log('')
-        log('  fintoc login --api-key sk_test_...')
-        process.exit(1)
-      }
+    const rootApiKey = actionCmd.parent?.opts().apiKey as string | undefined
+    if (rootApiKey) {
+      secretKey = rootApiKey
+    } else if (process.stdin.isTTY) {
+      secretKey = await password({ message: 'Enter your Fintoc secret key:' })
+    } else {
+      error('Non-interactive terminal detected. Pass the key via flag:')
+      hint('')
+      hint('  fintoc login --api-key sk_test_...')
+      process.exit(1)
+    }
 
-      if (!secretKey) {
-        error('No key provided')
-        process.exit(1)
-      }
+    if (!secretKey) {
+      error('No key provided')
+      process.exit(1)
+    }
+
+    try {
+      const info = await whoami(secretKey)
 
       try {
-        const info = await whoami(secretKey)
-
-        try {
-          writeConfig({ ...readConfig(), secret_key: secretKey })
-        } catch {
-          error(`Key is valid but could not write to ${CONFIG_PATH}`)
-          process.exit(1)
-        }
-
-        success(`Authenticated as ${info.organizationName} (${info.mode} mode)`)
-        log(`  Key stored in ${CONFIG_PATH}`)
-      } catch (err) {
-        handleError(err)
+        writeConfig({ ...readConfig(), secret_key: secretKey })
+      } catch {
+        error(`Key is valid but could not write to ${CONFIG_PATH}`)
+        process.exit(1)
       }
-    })
+
+      success(`Authenticated as ${info.organizationName} (${info.mode} mode)`)
+      hint(`  Key stored in ${CONFIG_PATH}`)
+    } catch (err) {
+      handleError(err)
+    }
+  })
 }

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,14 +1,12 @@
 import type { Command } from 'commander'
-
 import { clearConfig, CONFIG_PATH } from '../lib/config.js'
 import { success } from '../lib/output.js'
 
 export const logoutCommand = (program: Command) => {
-  program
-    .command('logout')
-    .description('Remove stored credentials')
-    .action(() => {
-      clearConfig()
-      success(`Credentials removed from ${CONFIG_PATH}`)
-    })
+  const cmd = program.command('logout').description('Remove stored credentials')
+  cmd.configureHelp({ showGlobalOptions: true })
+  cmd.action(() => {
+    clearConfig()
+    success(`Credentials removed from ${CONFIG_PATH}`)
+  })
 }

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -1,6 +1,6 @@
 import type { Command } from 'commander'
 import { exec } from 'node:child_process'
-
+import { addDefaultAction } from '../lib/commands.js'
 import { DASHBOARD_URL } from '../lib/constants.js'
 import { error, success } from '../lib/output.js'
 
@@ -32,6 +32,7 @@ const openInBrowser = (url: string): Promise<void> => {
 
 export const openCommand = (program: Command) => {
   const open = program.command('open').description('Open Fintoc resources in the browser')
+  open.configureHelp({ showGlobalOptions: true })
 
   open
     .command('dashboard')
@@ -39,4 +40,6 @@ export const openCommand = (program: Command) => {
     .action(async () => {
       await openInBrowser(DASHBOARD_URL)
     })
+
+  addDefaultAction(open)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import type { Help, Option } from 'commander'
 import { Command, CommanderError } from 'commander'
-
 import { configCommand } from './commands/config.js'
 import { doctorCommand } from './commands/doctor.js'
 import { loginCommand } from './commands/login.js'
@@ -56,6 +55,7 @@ program
   .version(versionString, '-v, --version')
   .option('--api-key <key>', 'Override API key for this command')
   .option('--json', 'Output as JSON')
+  .option('--no-color', 'Disable colored output')
   .exitOverride()
   .showSuggestionAfterError(true)
   .configureOutput({
@@ -123,6 +123,14 @@ program.configureHelp({
 
     return lines.join('\n')
   },
+})
+
+program.hook('preAction', (thisCommand) => {
+  const opts = thisCommand.opts<{ color?: boolean }>()
+  if (opts.color === false) {
+    delete process.env.FORCE_COLOR
+    process.env.NO_COLOR = '1'
+  }
 })
 
 addDefaultAction(program)

--- a/src/lib/__tests__/errors.test.ts
+++ b/src/lib/__tests__/errors.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { handleError } from '../errors.js'
-import { error, log } from '../output.js'
+import { error, hint } from '../output.js'
 
 vi.mock('../output.js', () => ({
   log: vi.fn(),
   error: vi.fn(),
+  hint: vi.fn(),
 }))
 
 // Helper to create a FintocError-like error with a specific constructor name.
@@ -55,8 +56,8 @@ describe('handleError', () => {
       expect(() => handleError(err)).toThrow('process.exit')
 
       expect(error).toHaveBeenCalledWith('No API key found. To authenticate:')
-      expect(log).toHaveBeenCalledWith('  Run:   fintoc login')
-      expect(log).toHaveBeenCalledWith(
+      expect(hint).toHaveBeenCalledWith('  Run:   fintoc login')
+      expect(hint).toHaveBeenCalledWith(
         '  Get your API keys at: https://dashboard.fintoc.com/api-keys',
       )
       expect(exitSpy).toHaveBeenCalledWith(1)
@@ -72,7 +73,7 @@ describe('handleError', () => {
         expect(() => handleError(err)).toThrow('process.exit')
 
         expect(error).toHaveBeenCalledWith('Could not connect to api.fintoc.com')
-        expect(log).toHaveBeenCalledWith('  Check your internet connection, or run: fintoc doctor')
+        expect(hint).toHaveBeenCalledWith('  Check your internet connection, or run: fintoc doctor')
       },
     )
   })
@@ -89,7 +90,25 @@ describe('handleError', () => {
       expect(() => handleError(err)).toThrow('process.exit')
 
       expect(error).toHaveBeenCalledWith('JWS private key required for transfer operations')
-      expect(log).toHaveBeenCalledWith('  More info:  https://docs.fintoc.com/docs/transfers')
+      expect(hint).toHaveBeenCalledWith('  More info:  https://docs.fintoc.com/docs/transfers')
+    })
+  })
+
+  describe('invalid link token', () => {
+    test('formats invalid_link_token error with next steps', () => {
+      const err = createFintocError('InvalidRequestError', {
+        type: 'invalid_request_error',
+        code: 'invalid_link_token',
+        param: 'link_token',
+        message: 'Invalid link access token',
+      })
+
+      expect(() => handleError(err)).toThrow('process.exit')
+
+      expect(error).toHaveBeenCalledWith('Invalid link token format')
+      expect(hint).toHaveBeenCalledWith(
+        '  Link tokens use the format: LINK_ID_token_LINK_ACCESS_TOKEN',
+      )
     })
   })
 
@@ -106,16 +125,16 @@ describe('handleError', () => {
         handleError(err, { cliPath: 'payment_intents', verb: 'get', id: 'pi_invalid' }),
       ).toThrow('process.exit')
 
-      expect(error).toHaveBeenCalledWith("Error (404): 'pi_invalid' not found")
-      expect(log).toHaveBeenCalledWith('  List available: fintoc payment_intents list')
+      expect(error).toHaveBeenCalledWith('Error (404): No such payment_intent: pi_invalid')
+      expect(hint).toHaveBeenCalledWith('  List available: fintoc payment_intents list')
     })
 
-    test('formats not found error without ID', () => {
+    test('formats not found error without ID and no API message', () => {
       const err = createFintocError('InvalidRequestError', {
         type: 'invalid_request_error',
         code: 'missing_resource',
         param: 'id',
-        message: 'No such payment_intent: pi_invalid',
+        message: '',
       })
 
       expect(() => handleError(err, { cliPath: 'payment_intents', verb: 'get' })).toThrow(
@@ -123,6 +142,36 @@ describe('handleError', () => {
       )
 
       expect(error).toHaveBeenCalledWith('Error (404): Resource not found')
+    })
+
+    test('falls back to id-based message when API message is empty', () => {
+      const err = createFintocError('InvalidRequestError', {
+        type: 'invalid_request_error',
+        code: 'missing_resource',
+        param: 'id',
+        message: '',
+      })
+
+      expect(() =>
+        handleError(err, { cliPath: 'payment_intents', verb: 'get', id: 'pi_invalid' }),
+      ).toThrow('process.exit')
+
+      expect(error).toHaveBeenCalledWith("Error (404): 'pi_invalid' not found")
+    })
+
+    test('shows API message when missing_resource is not a classic 404', () => {
+      const err = createFintocError('InvalidRequestError', {
+        type: 'invalid_request_error',
+        code: 'missing_resource',
+        param: 'enabled_events',
+        message: 'No such event: ["link.created"]',
+      })
+
+      expect(() => handleError(err, { cliPath: 'webhook_endpoints', verb: 'create' })).toThrow(
+        'process.exit',
+      )
+
+      expect(error).toHaveBeenCalledWith('Error (404): No such event: ["link.created"]')
     })
   })
 
@@ -136,8 +185,8 @@ describe('handleError', () => {
       expect(() => handleError(err)).toThrow('process.exit')
 
       expect(error).toHaveBeenCalledWith('Authentication failed: Invalid API key')
-      expect(log).toHaveBeenCalledWith('  Check your API key and try again.')
-      expect(log).toHaveBeenCalledWith(
+      expect(hint).toHaveBeenCalledWith('  Check your API key and try again.')
+      expect(hint).toHaveBeenCalledWith(
         '  Get your API keys at: https://dashboard.fintoc.com/api-keys',
       )
     })
@@ -198,7 +247,7 @@ describe('handleError', () => {
         handleError(err, { cliPath: 'payment_intents', verb: 'get', id: 'pi_bad' }),
       ).toThrow('process.exit')
 
-      expect(error).toHaveBeenCalledWith("Error (404): 'pi_bad' not found")
+      expect(error).toHaveBeenCalledWith('Error (404): No such resource')
     })
 
     test('handles AxiosError with JWS missing code', () => {

--- a/src/lib/__tests__/output.test.ts
+++ b/src/lib/__tests__/output.test.ts
@@ -80,6 +80,28 @@ describe('supportsColor', () => {
       expect(supportsColor()).toBe(!!process.stdout.isTTY)
     })
   })
+
+  describe('when --no-color sets NO_COLOR after cache is empty', () => {
+    test('respects NO_COLOR set before first call', () => {
+      const { FORCE_COLOR: _fc, NO_COLOR: _nc, ...envWithout } = originalEnv
+      process.env = envWithout
+
+      process.env.NO_COLOR = '1'
+
+      expect(supportsColor()).toBe(false)
+      expect(supportsColor()).toBe(false)
+    })
+
+    test('cache locks in the value from the first call', () => {
+      process.env = { ...originalEnv, FORCE_COLOR: '1' }
+
+      expect(supportsColor()).toBe(true)
+
+      process.env.NO_COLOR = '1'
+      delete process.env.FORCE_COLOR
+      expect(supportsColor()).toBe(true)
+    })
+  })
 })
 
 describe('colorizeStatus without color', () => {
@@ -107,8 +129,8 @@ describe('console wrappers', () => {
     expect(spy).toHaveBeenCalledWith('hello')
   })
 
-  test('success writes to stdout with ✔ prefix', () => {
-    const spy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  test('success writes to stderr with ✔ prefix', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
     success('done')
     expect(spy).toHaveBeenCalledWith('✔ done')
   })
@@ -220,18 +242,22 @@ describe('printTable', () => {
   })
 
   describe('when rows are empty', () => {
-    test('prints no results message', () => {
-      const spy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    test('prints no results message to stderr', () => {
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
       printTable({ columns: ['id'], rows: [] })
       expect(spy).toHaveBeenCalledWith('No results found.')
     })
   })
 
   describe('when rows have data', () => {
-    test('prints header and rows', () => {
-      const calls: string[] = []
+    test('prints header and rows to stdout, footer to stderr', () => {
+      const stdoutCalls: string[] = []
+      const stderrCalls: string[] = []
       vi.spyOn(console, 'log').mockImplementation((msg: string) => {
-        calls.push(msg)
+        stdoutCalls.push(msg)
+      })
+      vi.spyOn(console, 'error').mockImplementation((msg: string) => {
+        stderrCalls.push(msg)
       })
 
       printTable({
@@ -242,11 +268,13 @@ describe('printTable', () => {
         ],
       })
 
-      expect(calls[0]).toContain('ID')
-      expect(calls[0]).toContain('STATUS')
-      expect(calls[1]).toContain('pi_123')
-      expect(calls[2]).toContain('pi_456')
-      expect(calls[4]).toContain('Showing 2 results')
+      expect(stdoutCalls[0]).toContain('ID')
+      expect(stdoutCalls[0]).toContain('STATUS')
+      expect(stdoutCalls[1]).toContain('pi_123')
+      expect(stdoutCalls[2]).toContain('pi_456')
+      expect(stderrCalls).toEqual(
+        expect.arrayContaining([expect.stringContaining('Showing 2 results')]),
+      )
     })
 
     test('resolves nested paths in columns', () => {
@@ -266,9 +294,10 @@ describe('printTable', () => {
     })
 
     test('uses singular "result" for single row', () => {
-      const calls: string[] = []
-      vi.spyOn(console, 'log').mockImplementation((msg: string) => {
-        calls.push(msg)
+      const stderrCalls: string[] = []
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+      vi.spyOn(console, 'error').mockImplementation((msg: string) => {
+        stderrCalls.push(msg)
       })
 
       printTable({
@@ -276,16 +305,17 @@ describe('printTable', () => {
         rows: [{ id: 'pi_123' }],
       })
 
-      const footer = calls.find((c) => c.includes('Showing'))
+      const footer = stderrCalls.find((c) => c.includes('Showing'))
       expect(footer).toContain('1 result')
     })
   })
 
   describe('when total exceeds shown', () => {
     test('shows "X of Y" in footer', () => {
-      const calls: string[] = []
-      vi.spyOn(console, 'log').mockImplementation((msg: string) => {
-        calls.push(msg)
+      const stderrCalls: string[] = []
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+      vi.spyOn(console, 'error').mockImplementation((msg: string) => {
+        stderrCalls.push(msg)
       })
 
       printTable({
@@ -294,7 +324,7 @@ describe('printTable', () => {
         total: 50,
       })
 
-      const footer = calls.find((c) => c.includes('Showing'))
+      const footer = stderrCalls.find((c) => c.includes('Showing'))
       expect(footer).toContain('1 of 50')
     })
   })

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,4 @@
 import { Fintoc } from 'fintoc'
-
 import { readConfig } from './config.js'
 import { DASHBOARD_API_KEYS_URL } from './constants.js'
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,5 +1,10 @@
-import { API_HOST, DASHBOARD_API_KEYS_URL, DOCS_TRANSFERS_URL } from './constants.js'
-import { error, log } from './output.js'
+import {
+  API_HOST,
+  DASHBOARD_API_KEYS_URL,
+  DOCS_LINKS_URL,
+  DOCS_TRANSFERS_URL,
+} from './constants.js'
+import { error, hint } from './output.js'
 
 type ErrorContext = {
   cliPath?: string
@@ -83,8 +88,8 @@ const isConnectivityError = (err: unknown): boolean => {
 }
 
 const printNextSteps = (steps: string[]) => {
-  log('')
-  steps.forEach((step) => log(`  ${step}`))
+  hint('')
+  steps.forEach((step) => hint(`  ${step}`))
 }
 
 const exitJsonError = (fields: { type: string; code?: string; message: string }): never => {
@@ -141,9 +146,19 @@ export const handleError = (err: unknown, context?: ErrorContext): never => {
       return process.exit(1)
     }
 
+    if (fields.code === 'invalid_link_token') {
+      error('Invalid link token format')
+      printNextSteps([
+        'Link tokens use the format: LINK_ID_token_LINK_ACCESS_TOKEN',
+        'You can find link tokens in the response when creating a link.',
+        `More info:  ${DOCS_LINKS_URL}`,
+      ])
+      return process.exit(1)
+    }
+
     if (fields.code === 'missing_resource') {
-      const label = context?.id ? `'${context.id}' not found` : 'Resource not found'
-      error(`Error (404): ${label}`)
+      const fallback = context?.id ? `'${context.id}' not found` : 'Resource not found'
+      error(`Error (404): ${fields.message?.trim() || fallback}`)
       if (context?.cliPath) {
         printNextSteps([`List available: fintoc ${context.cliPath} list`])
       }

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -6,11 +6,15 @@ export const log = (message: string) => {
 }
 
 export const success = (message: string) => {
-  console.log(`✔ ${message}`)
+  console.error(`✔ ${message}`)
 }
 
 export const error = (message: string) => {
   console.error(`✘ ${message}`)
+}
+
+export const hint = (message: string) => {
+  console.error(message)
 }
 
 export const warn = (message: string) => {
@@ -18,10 +22,11 @@ export const warn = (message: string) => {
 }
 
 export const info = (message: string) => {
-  console.log(`ℹ ${message}`)
+  console.error(`ℹ ${message}`)
 }
 
 // Color support detection: FORCE_COLOR > NO_COLOR > config.color > TTY check
+// Cached because --no-color sets NO_COLOR=1 in a preAction hook before any output runs.
 let _colorEnabled: boolean | undefined
 
 export const supportsColor = () => {
@@ -127,7 +132,7 @@ export const formatValue = (key: string, value: unknown) => {
 
 export const printTable = ({ columns, rows, total }: TableOptions) => {
   if (rows.length === 0) {
-    log('No results found.')
+    hint('No results found.')
     return
   }
 
@@ -154,12 +159,12 @@ export const printTable = ({ columns, rows, total }: TableOptions) => {
     log(`  ${line}`)
   }
 
-  log('')
+  hint('')
   const shown = rows.length
   if (total !== undefined && total > shown) {
-    log(`Showing ${shown} of ${total} results`)
+    hint(`Showing ${shown} of ${total} results`)
   } else {
-    log(`Showing ${shown} ${shown === 1 ? 'result' : 'results'}`)
+    hint(`Showing ${shown} ${shown === 1 ? 'result' : 'results'}`)
   }
 }
 

--- a/src/resources/__tests__/factory.test.ts
+++ b/src/resources/__tests__/factory.test.ts
@@ -4,7 +4,7 @@ import { confirm } from '@inquirer/prompts'
 import { Command } from 'commander'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { createClient, resolveAuth } from '../../lib/auth.js'
-import { error, log, printDetail, printJson, printTable, success } from '../../lib/output.js'
+import { error, hint, printDetail, printJson, printTable, success } from '../../lib/output.js'
 import { registerResourceCommands } from '../factory.js'
 
 vi.mock('node:fs', async (importOriginal) => {
@@ -23,6 +23,7 @@ vi.mock('../../lib/config.js', () => ({
 
 vi.mock('../../lib/output.js', () => ({
   log: vi.fn(),
+  hint: vi.fn(),
   success: vi.fn(),
   error: vi.fn(),
   printTable: vi.fn(),
@@ -347,7 +348,7 @@ describe('factory', () => {
           program.parseAsync(['transfers', 'create', '--currency', 'CLP'], { from: 'user' }),
         ).rejects.toThrow('process.exit')
 
-        expect(log).toHaveBeenCalledWith(expect.stringContaining('fintoc v2 transfers create'))
+        expect(hint).toHaveBeenCalledWith(expect.stringContaining('fintoc v2 transfers create'))
       })
     })
   })
@@ -755,7 +756,7 @@ describe('factory', () => {
         await program.parseAsync(['payment_intents', 'delete', 'pi_123'], { from: 'user' })
 
         expect(mockManager.delete).not.toHaveBeenCalled()
-        expect(log).toHaveBeenCalledWith('Aborted.')
+        expect(hint).toHaveBeenCalledWith('Aborted.')
 
         Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
       })

--- a/src/resources/factory.ts
+++ b/src/resources/factory.ts
@@ -8,7 +8,7 @@ import { addDefaultAction } from '../lib/commands.js'
 import { readConfig } from '../lib/config.js'
 import { DEFAULT_LIST_LIMIT } from '../lib/constants.js'
 import { handleError } from '../lib/errors.js'
-import { error, log, printDetail, printJson, printTable, success } from '../lib/output.js'
+import { error, hint, printDetail, printJson, printTable, success } from '../lib/output.js'
 
 type RootOpts = {
   apiKey?: string
@@ -159,14 +159,14 @@ const validateRequired = (cmd: Command, flags: FlagDef[], fullCliPath: string, v
 
   if (missing.length > 0) {
     error(`Missing required ${missing.length === 1 ? 'flag' : 'flags'}: ${missing.join(', ')}`)
-    log('')
-    log(
+    hint('')
+    hint(
       `  Usage: fintoc ${fullCliPath} ${verb} ${flags
         .filter((f) => f.required)
         .map((f) => `--${f.name} <${f.type}>`)
         .join(' ')}`,
     )
-    log(`  Help:  fintoc ${fullCliPath} ${verb} --help`)
+    hint(`  Help:  fintoc ${fullCliPath} ${verb} --help`)
     process.exit(1)
   }
 }
@@ -230,7 +230,7 @@ const registerCreate = (parent: Command, resource: ResourceDef) => {
         printJson(data)
       } else {
         success(`${resource.displayName} created`)
-        log('')
+        hint('')
         printDetail(data)
       }
     } catch (err) {
@@ -240,14 +240,18 @@ const registerCreate = (parent: Command, resource: ResourceDef) => {
 }
 
 const registerGet = (parent: Command, resource: ResourceDef) => {
-  const cmd = parent.command('get <id>').description(`Get a ${resource.displayName} by ID`)
-  cmd.action(async (id: string, _opts: unknown, actionCmd: Command) => {
+  const argName = resource.getArg?.name ?? 'id'
+  const cmd = parent
+    .command('get')
+    .description(`Get a ${resource.displayName} by ${argName.replace(/_/g, ' ')}`)
+  cmd.argument(`<${argName}>`, resource.getArg?.description)
+  cmd.action(async (identifier: string, _opts: unknown, actionCmd: Command) => {
     const rootOpts = getRootOpts(actionCmd)
     try {
       const client = resolveClient(rootOpts, resource)
       const manager = getManager(client, resource)
 
-      const result = await manager.get!(id)
+      const result = await manager.get!(identifier)
       const data = serialize(result)
 
       if (rootOpts.json) {
@@ -259,7 +263,7 @@ const registerGet = (parent: Command, resource: ResourceDef) => {
       handleError(err, {
         cliPath: resourceCliPath(resource),
         verb: 'get',
-        id,
+        id: identifier,
         json: rootOpts.json,
       })
     }
@@ -330,7 +334,7 @@ const registerDelete = (parent: Command, resource: ResourceDef) => {
         default: false,
       })
       if (!confirmed) {
-        log('Aborted.')
+        hint('Aborted.')
         return
       }
     }
@@ -370,7 +374,7 @@ const registerExpire = (parent: Command, resource: ResourceDef) => {
         default: false,
       })
       if (!confirmed) {
-        log('Aborted.')
+        hint('Aborted.')
         return
       }
     }
@@ -408,7 +412,7 @@ export const registerResourceCommands = (program: Command, resourceDefs: Resourc
 
     const resourceCmd = program
       .command(resource.cliCommand)
-      .description(`Manage ${resource.name.replace(/_/g, ' ')}`)
+      .description(`Manage ${resource.displayName}s`)
 
     resourceCmd.configureHelp({ showGlobalOptions: true })
 

--- a/src/resources/registry.ts
+++ b/src/resources/registry.ts
@@ -135,7 +135,7 @@ export const resources: ResourceDef[] = [
     sdkMethod: 'webhookEndpoints',
     sdkNamespace: 'v1',
     verbs: ['create', 'get', 'list', 'delete'],
-    priorityColumns: ['id', 'url', 'status', 'enabled_events', 'created_at'],
+    priorityColumns: ['id', 'name', 'url', 'status', 'created_at'],
     createFlags: [
       {
         name: 'url',
@@ -211,7 +211,14 @@ export const resources: ResourceDef[] = [
     sdkMethod: 'subscriptions',
     sdkNamespace: 'v1',
     verbs: ['get', 'list'],
-    priorityColumns: ['id', 'status', 'amount', 'currency', 'created_at'],
+    priorityColumns: [
+      'created_at',
+      'id',
+      'account.holder_name',
+      'account.holder_id',
+      'account.institution',
+      'status',
+    ],
     listFlags: [
       {
         name: 'since',
@@ -233,6 +240,10 @@ export const resources: ResourceDef[] = [
     sdkNamespace: 'v1',
     verbs: ['get', 'list', 'delete'],
     priorityColumns: ['id', 'holder_name', 'institution', 'status', 'created_at'],
+    getArg: {
+      name: 'link_token',
+      description: `Link token (format: LINK_ID_token_LINK_ACCESS_TOKEN, see ${DOCS_LINKS_URL})`,
+    },
     listFlags: [
       {
         name: 'status',

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export type ResourceDef = {
   priorityColumns: string[]
   createFlags?: FlagDef[]
   listFlags?: FlagDef[]
+  getArg?: { name: string; description: string }
 }
 
 export type SdkManager = {


### PR DESCRIPTION
## Contexto

Fixes de QA para la CLI: separación stdout/stderr, mensajes de error mejorados, y UX de help.

## Que hay de nuevo?

- [x] Nuevo helper `hint()` que escribe a stderr — separa data (stdout) de decoración (stderr)
- [x] `success()`, `info()`, footer de tablas y "No results" van a stderr
- [x] Mejor manejo de errores: `missing_resource` usa mensaje de la API, nuevo handler para `invalid_link_token`
- [x] Todos los subcomandos muestran global options (`--api-key`, `--json`) en su `--help`
- [x] `fintoc config --json` retorna JSON estructurado
- [x] `fintoc open` sin subcomando muestra help en vez de error
- [x] Flag `--no-color` para deshabilitar colores
- [x] Columnas actualizadas para `webhook_endpoints` y `subscriptions`
- [x] `links get` usa `link_token` como argumento con descripción del formato

## Tests

- [x] Tests unitarios actualizados

<sup>*Created with Claude Code `/create-pr` command*</sup>