### PR TITLE
[ONB-1830] Subcomando config show y QA fixes

### DIFF
--- a/src/commands/__tests__/config.test.ts
+++ b/src/commands/__tests__/config.test.ts
@@ -34,22 +34,39 @@ const createProgram = () => {
   return program
 }
 
-describe('config command', () => {
+describe('config show command', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  describe('when authenticated', () => {
+  const setupAuth = () => {
+    vi.mocked(resolveAuth).mockReturnValue({
+      secretKey: 'sk_test_abc123',
+      source: 'config',
+    })
+    vi.mocked(whoami).mockResolvedValue({
+      organizationName: 'Acme Corp',
+      mode: 'test',
+      apiVersion: '2023-03-15',
+    })
+  }
+
+  describe('when using explicit `config show`', () => {
     test('shows full config', async () => {
-      vi.mocked(resolveAuth).mockReturnValue({
-        secretKey: 'sk_test_abc123',
-        source: 'config',
-      })
-      vi.mocked(whoami).mockResolvedValue({
-        organizationName: 'Acme Corp',
-        mode: 'test',
-        apiVersion: '2023-03-15',
-      })
+      setupAuth()
+
+      const program = createProgram()
+      await program.parseAsync(['config', 'show'], { from: 'user' })
+
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('Acme Corp'))
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('test'))
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('config file'))
+    })
+  })
+
+  describe('when using `config` without subcommand (default)', () => {
+    test('shows full config', async () => {
+      setupAuth()
 
       const program = createProgram()
       await program.parseAsync(['config'], { from: 'user' })
@@ -62,18 +79,10 @@ describe('config command', () => {
 
   describe('when --json is passed', () => {
     test('outputs JSON when authenticated', async () => {
-      vi.mocked(resolveAuth).mockReturnValue({
-        secretKey: 'sk_test_abc123',
-        source: 'config',
-      })
-      vi.mocked(whoami).mockResolvedValue({
-        organizationName: 'Acme Corp',
-        mode: 'test',
-        apiVersion: '2023-03-15',
-      })
+      setupAuth()
 
       const program = createProgram()
-      await program.parseAsync(['--json', 'config'], { from: 'user' })
+      await program.parseAsync(['--json', 'config', 'show'], { from: 'user' })
 
       expect(printJson).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -96,7 +105,7 @@ describe('config command', () => {
       vi.mocked(whoami).mockRejectedValue(new Error('Network error'))
 
       const program = createProgram()
-      await program.parseAsync(['--json', 'config'], { from: 'user' })
+      await program.parseAsync(['--json', 'config', 'show'], { from: 'user' })
 
       expect(printJson).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -116,7 +125,7 @@ describe('config command', () => {
       })
 
       const program = createProgram()
-      await program.parseAsync(['--json', 'config'], { from: 'user' })
+      await program.parseAsync(['--json', 'config', 'show'], { from: 'user' })
 
       expect(printJson).toHaveBeenCalledWith(expect.objectContaining({ authenticated: false }))
       expect(log).not.toHaveBeenCalled()
@@ -130,7 +139,7 @@ describe('config command', () => {
       })
 
       const program = createProgram()
-      await program.parseAsync(['config'], { from: 'user' })
+      await program.parseAsync(['config', 'show'], { from: 'user' })
 
       expect(hint).toHaveBeenCalledWith(expect.stringContaining('Not authenticated'))
     })
@@ -145,7 +154,7 @@ describe('config command', () => {
       vi.mocked(whoami).mockRejectedValue(new Error('Network error'))
 
       const program = createProgram()
-      await program.parseAsync(['config'], { from: 'user' })
+      await program.parseAsync(['config', 'show'], { from: 'user' })
 
       expect(warn).toHaveBeenCalledWith(expect.stringContaining('Unable to reach Fintoc API'))
       expect(log).toHaveBeenCalledWith(expect.stringContaining('  -'))

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -15,71 +15,75 @@ const isConfigKey = (key: string): key is keyof FintocConfig => ALLOWED_KEYS.inc
 export const configCommand = (program: Command) => {
   const configCmd = program.command('config').description('Show or update CLI configuration')
   configCmd.configureHelp({ showGlobalOptions: true })
-  configCmd.action(async (_opts: unknown, cmd: Command) => {
-    let secretKey: string
-    let source: 'flag' | 'env' | 'config'
 
-    const sourceLabels = {
-      flag: 'inline flag (--api-key)',
-      env: 'env var (FINTOC_SECRET_KEY)',
-      config: 'config file',
-    } satisfies Record<string, string>
+  configCmd
+    .command('show', { isDefault: true })
+    .description('Show current configuration')
+    .action(async (_opts: unknown, cmd: Command) => {
+      let secretKey: string
+      let source: 'flag' | 'env' | 'config'
 
-    const rootOpts = cmd.parent!.opts<{ apiKey?: string; json?: boolean }>()
+      const sourceLabels = {
+        flag: 'inline flag (--api-key)',
+        env: 'env var (FINTOC_SECRET_KEY)',
+        config: 'config file',
+      } satisfies Record<string, string>
 
-    try {
-      const auth = resolveAuth(rootOpts)
-      secretKey = auth.secretKey
-      source = auth.source
-    } catch {
-      if (rootOpts.json) {
-        printJson({ authenticated: false, config_path: CONFIG_PATH })
+      const rootOpts = cmd.optsWithGlobals<{ apiKey?: string; json?: boolean }>()
+
+      try {
+        const auth = resolveAuth(rootOpts)
+        secretKey = auth.secretKey
+        source = auth.source
+      } catch {
+        if (rootOpts.json) {
+          printJson({ authenticated: false, config_path: CONFIG_PATH })
+          return
+        }
+        hint('Not authenticated. Run `fintoc login` to get started.')
+        hint('')
+        hint(`  Config path:  ${CONFIG_PATH}`)
         return
       }
-      hint('Not authenticated. Run `fintoc login` to get started.')
-      hint('')
-      hint(`  Config path:  ${CONFIG_PATH}`)
-      return
-    }
 
-    let orgName: string | null = null
-    let mode: string | null = null
-    let apiVersion: string | null = null
-    let apiReachable = true
+      let orgName: string | null = null
+      let mode: string | null = null
+      let apiVersion: string | null = null
+      let apiReachable = true
 
-    try {
-      const info = await whoami(secretKey)
-      orgName = info.organizationName
-      mode = info.mode
-      apiVersion = info.apiVersion
-    } catch {
-      apiReachable = false
-      if (!rootOpts.json) {
-        warn('Unable to reach Fintoc API — showing cached config')
+      try {
+        const info = await whoami(secretKey)
+        orgName = info.organizationName
+        mode = info.mode
+        apiVersion = info.apiVersion
+      } catch {
+        apiReachable = false
+        if (!rootOpts.json) {
+          warn('Unable to reach Fintoc API — showing cached config')
+        }
       }
-    }
 
-    if (rootOpts.json) {
-      printJson({
-        authenticated: true,
-        organization: orgName,
-        mode,
-        secret_key: maskKey(secretKey),
-        api_version: apiVersion,
-        config_path: CONFIG_PATH,
-        source,
-        api_reachable: apiReachable,
-      })
-      return
-    }
+      if (rootOpts.json) {
+        printJson({
+          authenticated: true,
+          organization: orgName,
+          mode,
+          secret_key: maskKey(secretKey),
+          api_version: apiVersion,
+          config_path: CONFIG_PATH,
+          source,
+          api_reachable: apiReachable,
+        })
+        return
+      }
 
-    log(`  Organization:  ${orgName ?? '-'}`)
-    log(`  Mode:          ${mode ?? '-'}`)
-    log(`  Secret key:    ${maskKey(secretKey)}`)
-    log(`  API version:   ${apiVersion ?? '-'}`)
-    log(`  Config path:   ${CONFIG_PATH}`)
-    log(`  Source:        ${sourceLabels[source]}`)
-  })
+      log(`  Organization:  ${orgName ?? '-'}`)
+      log(`  Mode:          ${mode ?? '-'}`)
+      log(`  Secret key:    ${maskKey(secretKey)}`)
+      log(`  API version:   ${apiVersion ?? '-'}`)
+      log(`  Config path:   ${CONFIG_PATH}`)
+      log(`  Source:        ${sourceLabels[source]}`)
+    })
 
   configCmd
     .command('set <key> <value>')

--- a/src/lib/__tests__/errors.test.ts
+++ b/src/lib/__tests__/errors.test.ts
@@ -122,7 +122,12 @@ describe('handleError', () => {
       })
 
       expect(() =>
-        handleError(err, { cliPath: 'payment_intents', verb: 'get', id: 'pi_invalid' }),
+        handleError(err, {
+          cliPath: 'payment_intents',
+          verb: 'get',
+          id: 'pi_invalid',
+          availableVerbs: ['get', 'list'],
+        }),
       ).toThrow('process.exit')
 
       expect(error).toHaveBeenCalledWith('Error (404): No such payment_intent: pi_invalid')
@@ -142,6 +147,7 @@ describe('handleError', () => {
       )
 
       expect(error).toHaveBeenCalledWith('Error (404): Resource not found')
+      expect(hint).not.toHaveBeenCalledWith(expect.stringContaining('List available'))
     })
 
     test('falls back to id-based message when API message is empty', () => {
@@ -157,6 +163,7 @@ describe('handleError', () => {
       ).toThrow('process.exit')
 
       expect(error).toHaveBeenCalledWith("Error (404): 'pi_invalid' not found")
+      expect(hint).not.toHaveBeenCalledWith(expect.stringContaining('List available'))
     })
 
     test('shows API message when missing_resource is not a classic 404', () => {

--- a/src/lib/__tests__/output.test.ts
+++ b/src/lib/__tests__/output.test.ts
@@ -232,7 +232,12 @@ describe('formatValue', () => {
 
   test('formats object without name as JSON', () => {
     const obj = { id: 'abc', country: 'cl' }
-    expect(formatValue('metadata', obj)).toBe(JSON.stringify(obj))
+    expect(formatValue('metadata', obj)).toBe(JSON.stringify(obj, null, 2))
+  })
+
+  test('formats object without name as compact JSON when inline', () => {
+    const obj = { id: 'abc', country: 'cl' }
+    expect(formatValue('metadata', obj, { inline: true })).toBe(JSON.stringify(obj))
   })
 })
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -11,6 +11,7 @@ type ErrorContext = {
   verb?: string
   id?: string
   json?: boolean
+  availableVerbs?: string[]
 }
 
 // The SDK builds error messages as: "type[: code][ (param)]\nmessage[\nCheck the docs...]"
@@ -159,7 +160,7 @@ export const handleError = (err: unknown, context?: ErrorContext): never => {
     if (fields.code === 'missing_resource') {
       const fallback = context?.id ? `'${context.id}' not found` : 'Resource not found'
       error(`Error (404): ${fields.message?.trim() || fallback}`)
-      if (context?.cliPath) {
+      if (context?.cliPath && context.availableVerbs?.includes('list')) {
         printNextSteps([`List available: fintoc ${context.cliPath} list`])
       }
       return process.exit(1)

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -107,7 +107,7 @@ export type TableOptions = {
   total?: number
 }
 
-export const formatValue = (key: string, value: unknown) => {
+export const formatValue = (key: string, value: unknown, { inline = false } = {}) => {
   if (value === null || value === undefined) {
     return dim('—')
   }
@@ -125,7 +125,7 @@ export const formatValue = (key: string, value: unknown) => {
     if (typeof obj.name === 'string') {
       return obj.name
     }
-    return JSON.stringify(value)
+    return inline ? JSON.stringify(value) : JSON.stringify(value, null, 2)
   }
   return String(value)
 }
@@ -137,7 +137,7 @@ export const printTable = ({ columns, rows, total }: TableOptions) => {
   }
 
   const formattedRows = rows.map((row) =>
-    columns.map((col) => formatValue(toLabel(col), getNestedValue(row, col))),
+    columns.map((col) => formatValue(toLabel(col), getNestedValue(row, col), { inline: true })),
   )
 
   const headers = columns.map((col) => toLabel(col).toUpperCase())
@@ -181,10 +181,12 @@ export const printDetail = (data: Record<string, unknown>, columns?: string[]) =
   const labels = keys.map((k) => toLabel(k))
   const maxKeyLen = Math.max(...labels.map((l) => l.length))
 
+  const indent = ' '.repeat(maxKeyLen + 2)
   for (let i = 0; i < keys.length; i++) {
     const value = getNestedValue(data, keys[i])
     const label = labels[i].padEnd(maxKeyLen)
     const formatted = formatValue(labels[i], value)
-    log(`${label}  ${formatted}`)
+    const indented = formatted.replace(/\n/g, `\n${indent}`)
+    log(`${label}  ${indented}`)
   }
 }

--- a/src/resources/__tests__/factory.test.ts
+++ b/src/resources/__tests__/factory.test.ts
@@ -700,7 +700,7 @@ describe('factory', () => {
           program.parseAsync(['payment_intents', 'list', '--limit', value], { from: 'user' }),
         ).rejects.toThrow('process.exit')
 
-        expect(error).toHaveBeenCalledWith('--limit must be a positive number')
+        expect(error).toHaveBeenCalledWith('--limit must be a positive integer')
         expect(mockManager.list).not.toHaveBeenCalled()
       })
     })

--- a/src/resources/factory.ts
+++ b/src/resources/factory.ts
@@ -234,7 +234,12 @@ const registerCreate = (parent: Command, resource: ResourceDef) => {
         printDetail(data)
       }
     } catch (err) {
-      handleError(err, { cliPath: resourceCliPath(resource), verb: 'create', json: rootOpts.json })
+      handleError(err, {
+        cliPath: resourceCliPath(resource),
+        verb: 'create',
+        json: rootOpts.json,
+        availableVerbs: resource.verbs,
+      })
     }
   })
 }
@@ -265,6 +270,7 @@ const registerGet = (parent: Command, resource: ResourceDef) => {
         verb: 'get',
         id: identifier,
         json: rootOpts.json,
+        availableVerbs: resource.verbs,
       })
     }
   })
@@ -282,8 +288,8 @@ const registerList = (parent: Command, resource: ResourceDef) => {
     const rootOpts = getRootOpts(actionCmd)
     const localOpts = actionCmd.opts<{ limit: string }>()
     const limit = Number(localOpts.limit)
-    if (Number.isNaN(limit) || limit <= 0) {
-      error('--limit must be a positive number')
+    if (Number.isNaN(limit) || !Number.isInteger(limit) || limit <= 0) {
+      error('--limit must be a positive integer')
       process.exit(1)
     }
 
@@ -311,7 +317,12 @@ const registerList = (parent: Command, resource: ResourceDef) => {
         })
       }
     } catch (err) {
-      handleError(err, { cliPath: resourceCliPath(resource), verb: 'list', json: rootOpts.json })
+      handleError(err, {
+        cliPath: resourceCliPath(resource),
+        verb: 'list',
+        json: rootOpts.json,
+        availableVerbs: resource.verbs,
+      })
     }
   })
 }
@@ -351,6 +362,7 @@ const registerDelete = (parent: Command, resource: ResourceDef) => {
         verb: 'delete',
         id,
         json: rootOpts.json,
+        availableVerbs: resource.verbs,
       })
     }
   })
@@ -391,6 +403,7 @@ const registerExpire = (parent: Command, resource: ResourceDef) => {
         verb: 'expire',
         id,
         json: rootOpts.json,
+        availableVerbs: resource.verbs,
       })
     }
   })

--- a/src/resources/registry.ts
+++ b/src/resources/registry.ts
@@ -239,7 +239,7 @@ export const resources: ResourceDef[] = [
     sdkMethod: 'links',
     sdkNamespace: 'v1',
     verbs: ['get', 'list', 'delete'],
-    priorityColumns: ['id', 'holder_name', 'institution', 'status', 'created_at'],
+    priorityColumns: ['id', 'holder_id', 'institution', 'status', 'created_at'],
     getArg: {
       name: 'link_token',
       description: `Link token (format: LINK_ID_token_LINK_ACCESS_TOKEN, see ${DOCS_LINKS_URL})`,


### PR DESCRIPTION
## Contexto

Prepara `config` para futuros subcomandos y corrige issues de QA.

## Que hay de nuevo?

- [x] `config show` como subcomando con `isDefault: true` (retrocompatible)
- [x] Error 404 solo sugiere `list` si el recurso lo soporta
- [x] `--limit` rechaza decimales, links usa `holder_id`, pretty-print en detail view

## Tests

- [x] Tests unitarios para config show, error handling y output formatting

<sup>*Created with Claude Code `/create-pr` command*</sup>