### PR TITLE
[ONB-1915] Pass fintoc-cli user agent to SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@inquirer/prompts": "^8.4.2",
         "commander": "^14.0.3",
-        "fintoc": "^1.18.0",
+        "fintoc": "^1.19.0",
         "smol-toml": "^1.6.1"
       },
       "bin": {
@@ -4437,9 +4437,9 @@
       }
     },
     "node_modules/fintoc": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/fintoc/-/fintoc-1.18.0.tgz",
-      "integrity": "sha512-Ub1AExNEE2FA8331DLjiZAP1+05LShYlQxZu8SUAdskqdX87iycWre7tev4QZt859YEbD+CTG9ML0OK9NdbLCQ==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/fintoc/-/fintoc-1.19.0.tgz",
+      "integrity": "sha512-0GG8Pe4pDoSTjcaqUrG8gak7/2hJsL2h8XKNtP3BkOWhBn7vqR+AbTm0ThIcM7qTKI2AyDPtQa0OU9FNTmmI1A==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/node": "^22.15.18",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@inquirer/prompts": "^8.4.2",
     "commander": "^14.0.3",
-    "fintoc": "^1.18.0",
+    "fintoc": "^1.19.0",
     "smol-toml": "^1.6.1"
   },
   "devDependencies": {

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -1,9 +1,18 @@
+import { Fintoc } from 'fintoc'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { maskKey, resolveAuth } from '../auth.js'
+import { createClient, maskKey, resolveAuth } from '../auth.js'
 import { readConfig } from '../config.js'
+
+vi.mock('fintoc', () => ({
+  Fintoc: vi.fn(),
+}))
 
 vi.mock('../config.js', () => ({
   readConfig: vi.fn(),
+}))
+
+vi.mock('../version.js', () => ({
+  getCliVersion: vi.fn(() => '0.1.0'),
 }))
 
 describe('resolveAuth', () => {
@@ -77,6 +86,26 @@ describe('resolveAuth', () => {
     vi.mocked(readConfig).mockReturnValue({})
 
     expect(() => resolveAuth()).toThrow('No API key found')
+  })
+})
+
+describe('createClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('passes fintoc-cli user agent to SDK', () => {
+    createClient('sk_test_123')
+    expect(Fintoc).toHaveBeenCalledWith('sk_test_123', undefined, {
+      userAgent: 'fintoc-cli/0.1.0',
+    })
+  })
+
+  test('forwards JWS private key to SDK', () => {
+    createClient('sk_test_123', '/path/to/key.pem')
+    expect(Fintoc).toHaveBeenCalledWith('sk_test_123', '/path/to/key.pem', {
+      userAgent: 'fintoc-cli/0.1.0',
+    })
   })
 })
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,7 @@
 import { Fintoc } from 'fintoc'
 import { readConfig } from './config.js'
 import { DASHBOARD_API_KEYS_URL } from './constants.js'
+import { getCliVersion } from './version.js'
 
 export type AuthSource = 'flag' | 'env' | 'config'
 
@@ -52,7 +53,9 @@ export const resolveAuth = (options?: { apiKey?: string }) => {
 }
 
 export const createClient = (secretKey: string, jwsPrivateKey?: string) => {
-  return new Fintoc(secretKey, jwsPrivateKey)
+  return new Fintoc(secretKey, jwsPrivateKey, {
+    userAgent: `fintoc-cli/${getCliVersion()}`,
+  })
 }
 
 export const whoami = async (secretKey: string) => {


### PR DESCRIPTION
## Contexto

Cada request del CLI se identifica como `fintoc-node/{version}`. Este cambio envía `fintoc-cli/{version}` como User-Agent para distinguir tráfico en logs.

## Que hay de nuevo?

- [x] `createClient()` pasa `{ userAgent: 'fintoc-cli/{version}' }` al constructor de `Fintoc`

## Tests

- [x] Tests unitarios para `createClient`

## Consideraciones

- Depende de la PR de fintoc-node (ONB-1914). Hasta que se mergee, TypeScript marca error de tipo.

<sup>*Created with Claude Code `/create-pr` command*</sup>