### PR TITLE
[ONB-1794] Add publishConfig and npm badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Fintoc CLI
 
+[![npm version](https://img.shields.io/npm/v/@fintoc/cli.svg)](https://www.npmjs.com/package/@fintoc/cli)
+
 Build, test, and manage your Fintoc integration right from the terminal.
 
 ![demo](docs/demo.gif)

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",


### PR DESCRIPTION
## Contexto

Se publicó `@fintoc/cli@0.1.0` en npm.

## Que hay de nuevo?

- [x] `publishConfig.access: "public"` en `package.json`
- [x] Badge de versión npm en el README

<sup>*Created with Claude Code `/create-pr` command*</sup>