### PR TITLE
[ONB-1919] Automatizar publicación a npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+      - run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,40 @@
+# Release
+
+## How to publish a new version
+
+1. Make sure you're on `main` with everything merged:
+
+```bash
+git checkout main && git pull
+```
+
+2. Bump the version (creates a commit + git tag automatically):
+
+```bash
+npm version patch   # 0.1.0 → 0.1.1
+npm version minor   # 0.1.1 → 0.2.0
+npm version major   # 0.2.0 → 1.0.0
+```
+
+3. Push the commit and tag:
+
+```bash
+git push && git push --tags
+```
+
+4. GitHub Actions detects the `v*` tag and automatically:
+   - Installs dependencies
+   - Builds the project
+   - Runs tests
+   - Publishes to npm with provenance
+
+5. Verify:
+
+```bash
+npm view @fintoc/cli version
+npx --package @fintoc/cli fintoc --version
+```
+
+## CI requirements
+
+The workflow requires a `NPM_TOKEN` secret configured in the repo (Settings → Secrets and variables → Actions). This is a Granular Access Token from npmjs.com with read/write permissions on `@fintoc/cli`.


### PR DESCRIPTION
## Contexto

La primera publicación de `@fintoc/cli@0.1.0` se hizo manual. Este PR automatiza las siguientes.

## Que hay de nuevo?

- [x] GitHub Action que publica a npm automáticamente al pushear un tag `v*` (build → test → publish con provenance)
- [x] `RELEASE.md` con guía paso a paso del flujo de release

<sup>*Created with Claude Code `/create-pr` command*</sup>