### PR TITLE
[ONB-1920] Agregar recursos v2: account_verifications, account_numbers, movements

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ Resources follow the pattern `fintoc <resource> <action> [flags]`.
 | `api_keys` | list |
 | `v2 transfers` | create, get, list |
 | `v2 accounts` | get, list |
+| `v2 account_verifications` | create, get, list |
+| `v2 account_numbers` | create, get, list, delete |
+| `v2 movements` | get, list |
 
 ### Utilities
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ fintoc charges create --amount 5000 --currency CLP --subscription-id sub_test_ab
 The CLI resolves your API key in this order:
 
 1. `--api-key` flag (inline, per-command)
-2. `FINTOC_SECRET_KEY` environment variable
+2. `FINTOC_API_KEY` environment variable
 3. `~/.fintoc/config.toml` (saved via `fintoc login`)
 
 ```bash

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -25,7 +25,7 @@ export const configCommand = (program: Command) => {
 
       const sourceLabels = {
         flag: 'inline flag (--api-key)',
-        env: 'env var (FINTOC_SECRET_KEY)',
+        env: 'env var (FINTOC_API_KEY)',
         config: 'config file',
       } satisfies Record<string, string>
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -61,7 +61,7 @@ const checkApiKey = (options?: { apiKey?: string }) => {
     return auth
   } catch {
     error('API key             not configured')
-    hint('                    Run `fintoc login` or set FINTOC_SECRET_KEY')
+    hint('                    Run `fintoc login` or set FINTOC_API_KEY')
     return null
   }
 }

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -16,23 +16,23 @@ vi.mock('../version.js', () => ({
 }))
 
 describe('resolveAuth', () => {
-  const originalEnv = process.env.FINTOC_SECRET_KEY
+  const originalEnv = process.env.FINTOC_API_KEY
 
   beforeEach(() => {
     vi.clearAllMocks()
-    delete process.env.FINTOC_SECRET_KEY
+    delete process.env.FINTOC_API_KEY
   })
 
   afterEach(() => {
     if (originalEnv !== undefined) {
-      process.env.FINTOC_SECRET_KEY = originalEnv
+      process.env.FINTOC_API_KEY = originalEnv
     } else {
-      delete process.env.FINTOC_SECRET_KEY
+      delete process.env.FINTOC_API_KEY
     }
   })
 
   test('returns flag value with highest priority', () => {
-    process.env.FINTOC_SECRET_KEY = 'sk_test_env'
+    process.env.FINTOC_API_KEY = 'sk_test_env'
     vi.mocked(readConfig).mockReturnValue({ secret_key: 'sk_test_config' })
 
     const result = resolveAuth({ apiKey: 'sk_test_flag' })
@@ -40,7 +40,7 @@ describe('resolveAuth', () => {
   })
 
   test('returns env value when no flag', () => {
-    process.env.FINTOC_SECRET_KEY = 'sk_test_env'
+    process.env.FINTOC_API_KEY = 'sk_test_env'
     vi.mocked(readConfig).mockReturnValue({ secret_key: 'sk_test_config' })
 
     const result = resolveAuth()
@@ -55,31 +55,31 @@ describe('resolveAuth', () => {
   })
 
   test('throws when --api-key is empty string', () => {
-    process.env.FINTOC_SECRET_KEY = 'sk_test_env'
+    process.env.FINTOC_API_KEY = 'sk_test_env'
     vi.mocked(readConfig).mockReturnValue({ secret_key: 'sk_test_config' })
 
     expect(() => resolveAuth({ apiKey: '' })).toThrow('API key is empty')
   })
 
   test('throws when --api-key is only whitespace', () => {
-    process.env.FINTOC_SECRET_KEY = 'sk_test_env'
+    process.env.FINTOC_API_KEY = 'sk_test_env'
     vi.mocked(readConfig).mockReturnValue({ secret_key: 'sk_test_config' })
 
     expect(() => resolveAuth({ apiKey: '   ' })).toThrow('API key is empty')
   })
 
-  test('throws when FINTOC_SECRET_KEY is empty string', () => {
-    process.env.FINTOC_SECRET_KEY = ''
+  test('throws when FINTOC_API_KEY is empty string', () => {
+    process.env.FINTOC_API_KEY = ''
     vi.mocked(readConfig).mockReturnValue({ secret_key: 'sk_test_config' })
 
-    expect(() => resolveAuth()).toThrow('FINTOC_SECRET_KEY is set but empty')
+    expect(() => resolveAuth()).toThrow('FINTOC_API_KEY is set but empty')
   })
 
-  test('throws when FINTOC_SECRET_KEY is only whitespace', () => {
-    process.env.FINTOC_SECRET_KEY = '   '
+  test('throws when FINTOC_API_KEY is only whitespace', () => {
+    process.env.FINTOC_API_KEY = '   '
     vi.mocked(readConfig).mockReturnValue({ secret_key: 'sk_test_config' })
 
-    expect(() => resolveAuth()).toThrow('FINTOC_SECRET_KEY is set but empty')
+    expect(() => resolveAuth()).toThrow('FINTOC_API_KEY is set but empty')
   })
 
   test('throws when no key found', () => {

--- a/src/lib/__tests__/errors.test.ts
+++ b/src/lib/__tests__/errors.test.ts
@@ -50,7 +50,7 @@ describe('handleError', () => {
   describe('no API key', () => {
     test('formats no-auth error with next steps', () => {
       const err = new Error(
-        'No API key found. To authenticate:\n\n  Run:   fintoc login\n  Or:    export FINTOC_SECRET_KEY=sk_test_...',
+        'No API key found. To authenticate:\n\n  Run:   fintoc login\n  Or:    export FINTOC_API_KEY=sk_test_...',
       )
 
       expect(() => handleError(err)).toThrow('process.exit')

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -24,12 +24,10 @@ export const resolveAuth = (options?: { apiKey?: string }) => {
     return { secretKey: options.apiKey, source: 'flag' as const }
   }
 
-  const envKey = process.env.FINTOC_SECRET_KEY
+  const envKey = process.env.FINTOC_API_KEY
   if (envKey !== undefined) {
     if (!envKey.trim()) {
-      throw new Error(
-        'FINTOC_SECRET_KEY is set but empty. Provide a valid key or unset the variable.',
-      )
+      throw new Error('FINTOC_API_KEY is set but empty. Provide a valid key or unset the variable.')
     }
     return { secretKey: envKey, source: 'env' as const }
   }
@@ -44,7 +42,7 @@ export const resolveAuth = (options?: { apiKey?: string }) => {
       'No API key found. To authenticate:',
       '',
       '  Run:   fintoc login',
-      '  Or:    export FINTOC_SECRET_KEY=sk_test_...',
+      '  Or:    export FINTOC_API_KEY=sk_test_...',
       '  Or:    fintoc --api-key sk_test_... <command>',
       '',
       `  Get your API keys at: ${DASHBOARD_API_KEYS_URL}`,

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -13,3 +13,7 @@ export const DOCS_PAYMENT_INTENTS_URL =
 export const DOCS_TRANSFERS_OBJECT_URL = 'https://docs.fintoc.com/reference/transfer-object.md'
 export const DOCS_CHARGES_URL = 'https://docs.fintoc.com/reference/charge-object.md'
 export const DOCS_LINKS_URL = 'https://docs.fintoc.com/reference/link-object.md'
+export const DOCS_ACCOUNT_VERIFICATIONS_URL =
+  'https://docs.fintoc.com/reference/account-verification-object.md'
+export const DOCS_ACCOUNT_NUMBERS_URL = 'https://docs.fintoc.com/reference/account-number-object.md'
+export const DOCS_MOVEMENTS_URL = 'https://docs.fintoc.com/reference/movement-object.md'

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -106,7 +106,7 @@ export const handleError = (err: unknown, context?: ErrorContext): never => {
     error('No API key found. To authenticate:')
     printNextSteps([
       'Run:   fintoc login',
-      'Or:    export FINTOC_SECRET_KEY=sk_test_...',
+      'Or:    export FINTOC_API_KEY=sk_test_...',
       'Or:    fintoc --api-key sk_test_... <command>',
       '',
       `Get your API keys at: ${DASHBOARD_API_KEYS_URL}`,

--- a/src/resources/__tests__/factory.test.ts
+++ b/src/resources/__tests__/factory.test.ts
@@ -604,7 +604,7 @@ describe('factory', () => {
         const program = createProgram()
         await program.parseAsync(['payment_intents', 'get', 'pi_123'], { from: 'user' })
 
-        expect(mockManager.get).toHaveBeenCalledWith('pi_123')
+        expect(mockManager.get).toHaveBeenCalledWith('pi_123', undefined)
         expect(printDetail).toHaveBeenCalledWith({ id: 'pi_123', amount: 10000 })
       })
     })
@@ -889,6 +889,94 @@ describe('factory', () => {
 
         expect(printJson).toHaveBeenCalledWith([{ id: 'tr_1' }])
         expect(printTable).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('nested SDK path (dotted sdkMethod)', () => {
+    const nestedManager = {
+      get: vi.fn(),
+      list: vi.fn(),
+    }
+
+    const nestedResource: ResourceDef = {
+      name: 'movements',
+      displayName: 'movement',
+      cliCommand: 'movements',
+      sdkMethod: 'accounts.movements',
+      sdkNamespace: 'v2',
+      verbs: ['get', 'list'],
+      priorityColumns: ['id', 'amount', 'currency'],
+      getFlags: [{ name: 'account-id', type: 'string', required: true, description: 'Account ID' }],
+      listFlags: [
+        { name: 'account-id', type: 'string', required: true, description: 'Account ID' },
+      ],
+    }
+
+    const setupNestedClient = () => {
+      const client = { v2: { accounts: { movements: nestedManager } } }
+      vi.mocked(createClient).mockReturnValue(client as unknown as ReturnType<typeof createClient>)
+    }
+
+    describe('when getting a resource with getFlags', () => {
+      test('passes getFlags as second argument to SDK get', async () => {
+        setupNestedClient()
+        const mockResult = { serialize: () => ({ id: 'mov_123', amount: 5000 }) }
+        nestedManager.get.mockResolvedValue(mockResult)
+
+        const program = createProgram(nestedResource)
+        await program.parseAsync(['movements', 'get', 'mov_123', '--account-id', 'acc_test_abc'], {
+          from: 'user',
+        })
+
+        expect(nestedManager.get).toHaveBeenCalledWith('mov_123', { account_id: 'acc_test_abc' })
+        expect(printDetail).toHaveBeenCalledWith({ id: 'mov_123', amount: 5000 })
+      })
+
+      test('exits with error when required getFlag is missing', async () => {
+        const exitSpy = mockProcessExit()
+
+        const program = createProgram(nestedResource)
+        await expect(
+          program.parseAsync(['movements', 'get', 'mov_123'], { from: 'user' }),
+        ).rejects.toThrow('process.exit')
+
+        expect(error).toHaveBeenCalledWith(
+          expect.stringContaining('Missing required flag: --account-id'),
+        )
+        expect(nestedManager.get).not.toHaveBeenCalled()
+        exitSpy.mockRestore()
+      })
+    })
+
+    describe('when listing resources with required listFlags', () => {
+      test('passes required listFlag to SDK list', async () => {
+        setupNestedClient()
+        nestedManager.list.mockResolvedValue(asyncGenerator([]))
+
+        const program = createProgram(nestedResource)
+        await program.parseAsync(['movements', 'list', '--account-id', 'acc_test_abc'], {
+          from: 'user',
+        })
+
+        expect(nestedManager.list).toHaveBeenCalledWith(
+          expect.objectContaining({ account_id: 'acc_test_abc', lazy: true }),
+        )
+      })
+
+      test('exits with error when required listFlag is missing', async () => {
+        const exitSpy = mockProcessExit()
+
+        const program = createProgram(nestedResource)
+        await expect(program.parseAsync(['movements', 'list'], { from: 'user' })).rejects.toThrow(
+          'process.exit',
+        )
+
+        expect(error).toHaveBeenCalledWith(
+          expect.stringContaining('Missing required flag: --account-id'),
+        )
+        expect(nestedManager.list).not.toHaveBeenCalled()
+        exitSpy.mockRestore()
       })
     })
   })

--- a/src/resources/__tests__/registry.test.ts
+++ b/src/resources/__tests__/registry.test.ts
@@ -3,8 +3,8 @@ import { resources, v1Resources, v2Resources } from '../registry.js'
 
 describe('resource registry', () => {
   describe('schema validation', () => {
-    test('contains all 9 resources', () => {
-      expect(resources).toHaveLength(9)
+    test('contains all 12 resources', () => {
+      expect(resources).toHaveLength(12)
 
       const names = resources.map((r) => r.name)
       expect(names).toEqual([
@@ -16,6 +16,9 @@ describe('resource registry', () => {
         'subscriptions',
         'links',
         'checkout_sessions',
+        'account_verifications',
+        'account_numbers',
+        'movements',
         'api_keys',
       ])
     })
@@ -59,6 +62,9 @@ describe('resource registry', () => {
         for (const flag of resource.listFlags ?? []) {
           expect(validTypes.has(flag.type)).toBe(true)
         }
+        for (const flag of resource.getFlags ?? []) {
+          expect(validTypes.has(flag.type)).toBe(true)
+        }
       }
     })
   })
@@ -73,7 +79,14 @@ describe('resource registry', () => {
     })
 
     test('all other resources use v1 namespace', () => {
-      const nonV2 = resources.filter((r) => !['transfers', 'accounts'].includes(r.name))
+      const v2Names = new Set([
+        'transfers',
+        'accounts',
+        'account_verifications',
+        'account_numbers',
+        'movements',
+      ])
+      const nonV2 = resources.filter((r) => !v2Names.has(r.name))
       for (const resource of nonV2) {
         expect(resource.sdkNamespace).toBe('v1')
       }
@@ -86,7 +99,13 @@ describe('resource registry', () => {
 
     test('v2Resources contains only v2 namespace resources', () => {
       expect(v2Resources.every((r) => r.sdkNamespace === 'v2')).toBe(true)
-      expect(v2Resources.map((r) => r.name)).toEqual(['transfers', 'accounts'])
+      expect(v2Resources.map((r) => r.name)).toEqual([
+        'transfers',
+        'accounts',
+        'account_verifications',
+        'account_numbers',
+        'movements',
+      ])
     })
   })
 
@@ -142,6 +161,35 @@ describe('resource registry', () => {
       const webhooks = resources.find((r) => r.name === 'webhook_endpoints')!
       const eventsFlag = webhooks.createFlags!.find((f) => f.name === 'enabled-events')!
       expect(eventsFlag.type).toBe('string[]')
+    })
+
+    test('account_verifications requires account-number and needs JWS', () => {
+      const av = resources.find((r) => r.name === 'account_verifications')!
+      expect(av.needsJws).toBe(true)
+      const requiredFlags = av.createFlags!.filter((f) => f.required)
+      expect(requiredFlags.map((f) => f.name)).toEqual(['account-number'])
+    })
+
+    test('account_numbers requires account-id for create', () => {
+      const an = resources.find((r) => r.name === 'account_numbers')!
+      const requiredFlags = an.createFlags!.filter((f) => f.required)
+      expect(requiredFlags.map((f) => f.name)).toEqual(['account-id'])
+    })
+
+    test('movements requires account-id for get and list', () => {
+      const movements = resources.find((r) => r.name === 'movements')!
+      expect(movements.getFlags).toBeDefined()
+      expect(movements.getFlags!.filter((f) => f.required).map((f) => f.name)).toEqual([
+        'account-id',
+      ])
+      expect(movements.listFlags!.filter((f) => f.required).map((f) => f.name)).toEqual([
+        'account-id',
+      ])
+    })
+
+    test('movements uses nested sdkMethod path', () => {
+      const movements = resources.find((r) => r.name === 'movements')!
+      expect(movements.sdkMethod).toBe('accounts.movements')
     })
   })
 })

--- a/src/resources/factory.ts
+++ b/src/resources/factory.ts
@@ -33,7 +33,14 @@ const resourceCliPath = (resource: ResourceDef) =>
 const getManager = (client: Fintoc, resource: ResourceDef) => {
   const base =
     resource.sdkNamespace === 'v2' ? (client as unknown as Record<string, unknown>).v2 : client
-  return (base as Record<string, unknown>)[resource.sdkMethod] as SdkManager
+  let current = base as Record<string, unknown>
+  for (const part of resource.sdkMethod.split('.')) {
+    current = current[part] as Record<string, unknown>
+    if (!current) {
+      throw new Error(`SDK path "${resource.sdkMethod}" not found at "${part}"`)
+    }
+  }
+  return current as unknown as SdkManager
 }
 
 const parseFlagValue = (value: string, flag: FlagDef) => {
@@ -250,13 +257,19 @@ const registerGet = (parent: Command, resource: ResourceDef) => {
     .command('get')
     .description(`Get a ${resource.displayName} by ${argName.replace(/_/g, ' ')}`)
   cmd.argument(`<${argName}>`, resource.getArg?.description)
+  addFlags(cmd, resource.getFlags ?? [])
   cmd.action(async (identifier: string, _opts: unknown, actionCmd: Command) => {
     const rootOpts = getRootOpts(actionCmd)
+    const flags = resource.getFlags ?? []
+
+    validateRequired(actionCmd, flags, resourceCliPath(resource), 'get')
+
     try {
       const client = resolveClient(rootOpts, resource)
       const manager = getManager(client, resource)
 
-      const result = await manager.get!(identifier)
+      const params = flags.length ? collectSetOptions(actionCmd, flags) : undefined
+      const result = await manager.get!(identifier, params)
       const data = serialize(result)
 
       if (rootOpts.json) {
@@ -286,6 +299,9 @@ const registerList = (parent: Command, resource: ResourceDef) => {
 
   cmd.action(async (_opts: unknown, actionCmd: Command) => {
     const rootOpts = getRootOpts(actionCmd)
+
+    validateRequired(actionCmd, resource.listFlags ?? [], resourceCliPath(resource), 'list')
+
     const localOpts = actionCmd.opts<{ limit: string }>()
     const limit = Number(localOpts.limit)
     if (Number.isNaN(limit) || !Number.isInteger(limit) || limit <= 0) {

--- a/src/resources/registry.ts
+++ b/src/resources/registry.ts
@@ -1,7 +1,10 @@
 import type { ResourceDef } from '../types.js'
 import {
+  DOCS_ACCOUNT_NUMBERS_URL,
+  DOCS_ACCOUNT_VERIFICATIONS_URL,
   DOCS_CHARGES_URL,
   DOCS_LINKS_URL,
+  DOCS_MOVEMENTS_URL,
   DOCS_PAYMENT_INTENTS_URL,
   DOCS_TRANSFERS_OBJECT_URL,
 } from '../lib/constants.js'
@@ -332,6 +335,94 @@ export const resources: ResourceDef[] = [
       },
     ],
     listFlags: [],
+  },
+  {
+    name: 'account_verifications',
+    displayName: 'account verification',
+    cliCommand: 'account_verifications',
+    sdkMethod: 'accountVerifications',
+    sdkNamespace: 'v2',
+    verbs: ['create', 'get', 'list'],
+    needsJws: true,
+    priorityColumns: [
+      'id',
+      'status',
+      'counterparty.account_number',
+      'counterparty.holder_name',
+      'reason',
+    ],
+    createFlags: [
+      {
+        name: 'account-number',
+        type: 'string',
+        required: true,
+        description: `Account to verify — CLABE, debit card, or phone number (see ${DOCS_ACCOUNT_VERIFICATIONS_URL})`,
+      },
+    ],
+    listFlags: [],
+  },
+  {
+    name: 'account_numbers',
+    displayName: 'account number',
+    cliCommand: 'account_numbers',
+    sdkMethod: 'accountNumbers',
+    sdkNamespace: 'v2',
+    verbs: ['create', 'get', 'list', 'delete'],
+    priorityColumns: ['id', 'number', 'description', 'status', 'is_root'],
+    createFlags: [
+      {
+        name: 'account-id',
+        type: 'string',
+        required: true,
+        description: 'Account ID to associate the account number with',
+      },
+      {
+        name: 'description',
+        type: 'string',
+        description: `Description to identify the account number (see ${DOCS_ACCOUNT_NUMBERS_URL})`,
+      },
+    ],
+    listFlags: [],
+  },
+  {
+    name: 'movements',
+    displayName: 'movement',
+    cliCommand: 'movements',
+    sdkMethod: 'accounts.movements',
+    sdkNamespace: 'v2',
+    verbs: ['get', 'list'],
+    priorityColumns: ['id', 'amount', 'currency', 'direction', 'balance', 'transaction_date'],
+    getFlags: [
+      {
+        name: 'account-id',
+        type: 'string',
+        required: true,
+        description: 'Account ID to retrieve the movement from',
+      },
+    ],
+    listFlags: [
+      {
+        name: 'account-id',
+        type: 'string',
+        required: true,
+        description: 'Account ID to list movements for',
+      },
+      {
+        name: 'since',
+        type: 'string',
+        description: 'Show results with post_date after this date (ISO 8601)',
+      },
+      {
+        name: 'until',
+        type: 'string',
+        description: 'Show results with post_date before this date (ISO 8601)',
+      },
+      {
+        name: 'resource-id',
+        type: 'string',
+        description: `Filter by associated resource ID (see ${DOCS_MOVEMENTS_URL})`,
+      },
+    ],
   },
   {
     name: 'api_keys',

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,12 +27,13 @@ export type ResourceDef = {
   priorityColumns: string[]
   createFlags?: FlagDef[]
   listFlags?: FlagDef[]
+  getFlags?: FlagDef[]
   getArg?: { name: string; description: string }
 }
 
 export type SdkManager = {
   create?: (body: Record<string, unknown>) => Promise<unknown>
-  get?: (id: string) => Promise<unknown>
+  get?: (id: string, params?: Record<string, unknown>) => Promise<unknown>
   list?: (params: Record<string, unknown>) => Promise<unknown>
   delete?: (id: string) => Promise<unknown>
   expire?: (id: string) => Promise<unknown>


### PR DESCRIPTION
## Contexto

Agrega los 3 recursos v2 restantes del SDK a la CLI.

## Que hay de nuevo?

- [x] Soporte para `getFlags` y `sdkMethod` con paths anidados en la factory
- [x] Validación de flags requeridos en `get` y `list`
- [x] Recursos: `account_verifications`, `account_numbers`, `movements`
- [x] Renombra `FINTOC_SECRET_KEY` → `FINTOC_API_KEY` para consistencia con `--api-key` (alineado con convención Stripe)

## Tests

- [x] Tests unitarios para factory y registry
- [x] Tests e2e locales con keys de producción

<sup>*Created with Claude Code `/create-pr` command*</sup>