### PR TITLE
[ONB-1795] Homebrew tap para instalación vía brew

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,0 +1,124 @@
+name: Update Homebrew Formula
+
+on:
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 0.1.1)'
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  update-formula:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Determine version
+        id: version
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="${INPUT_VERSION#v}"
+          else
+            VERSION=$(node -p 'require("./package.json").version')
+          fi
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid version: $VERSION"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for npm publish
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          for i in $(seq 1 30); do
+            if npm view "@fintoc/cli@$VERSION" version 2>/dev/null; then
+              echo "Found @fintoc/cli@$VERSION on npm"
+              exit 0
+            fi
+            echo "Attempt $i/30 — waiting 10s..."
+            sleep 10
+          done
+          echo "Timed out waiting for @fintoc/cli@$VERSION on npm"
+          npm view "@fintoc/cli" versions --json || true
+          exit 1
+
+      - name: Download tarball and compute SHA256
+        id: sha
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          URL="https://registry.npmjs.org/@fintoc/cli/-/cli-${VERSION}.tgz"
+          TARBALL=$(mktemp)
+          HTTP_CODE=$(curl -sL -o "$TARBALL" -w '%{http_code}' "$URL")
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "Failed to download tarball (HTTP $HTTP_CODE)"
+            exit 1
+          fi
+          SHA256=$(sha256sum "$TARBALL" | awk '{print $1}')
+          echo "sha256=$SHA256" >> "$GITHUB_OUTPUT"
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Clone homebrew-tap
+        uses: actions/checkout@v4
+        with:
+          repository: fintoc-com/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          path: homebrew-tap
+
+      - name: Update formula
+        env:
+          TARBALL_URL: ${{ steps.sha.outputs.url }}
+          TARBALL_SHA256: ${{ steps.sha.outputs.sha256 }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          for var in TARBALL_URL TARBALL_SHA256 VERSION; do
+            [ -z "${!var}" ] && echo "::error::$var is empty" && exit 1
+          done
+          envsubst '$TARBALL_URL $TARBALL_SHA256 $VERSION' > homebrew-tap/Formula/fintoc.rb <<'RUBY'
+class Fintoc < Formula
+  desc "CLI for the Fintoc API"
+  homepage "https://github.com/fintoc-com/fintoc-cli"
+  url "$TARBALL_URL"
+  version "$VERSION"
+  sha256 "$TARBALL_SHA256"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    assert_match "fintoc/#{version}", shell_output("#{bin}/fintoc --version")
+  end
+end
+RUBY
+
+      - name: Commit and push
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          cd homebrew-tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/fintoc.rb
+          if git diff --cached --quiet; then
+            echo "Formula already up to date"
+            exit 0
+          fi
+          git commit -m "fintoc $VERSION
+
+          https://github.com/fintoc-com/fintoc-cli/releases/tag/v$VERSION"
+          git push

--- a/README.md
+++ b/README.md
@@ -18,12 +18,20 @@ Build, test, and manage your Fintoc integration right from the terminal.
 
 ## Installation
 
+### npm
+
 ```bash
 npm install -g @fintoc/cli
 fintoc --version
 ```
 
 Requires Node.js >= 22.
+
+### Homebrew
+
+```bash
+brew install fintoc-com/tap/fintoc
+```
 
 ## Getting started
 


### PR DESCRIPTION
## Contexto
El repo `fintoc-com/homebrew-tap` tenía una formula que apuntaba al CLI de Go (ya deprecado). Ahora que el CLI de Node está publicado en npm, necesitamos que el tap apunte a `@fintoc/cli` y se actualice automáticamente en cada release.

## Que hay de nuevo?
- [x] Workflow `update-homebrew.yml` que se triggerea después del Release workflow
- [x] Espera que el paquete aparezca en npm, calcula SHA256, y actualiza la formula en `fintoc-com/homebrew-tap`
- [x] Soporte para `workflow_dispatch` manual con input de versión

## Consideraciones
- Se requiere crear el secret `HOMEBREW_TAP_GITHUB_TOKEN` en este repo (Fine-grained PAT con `Contents: write` sobre `homebrew-tap`)
- La formula en `homebrew-tap` ya fue actualizada directamente en main (commit `afbe1ed`)

<sup>*Created with Claude Code `/create-pr` command*</sup>