### PR TITLE
[ONB-1949] Add contributions documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The CLI resolves your API key in this order:
 3. `~/.fintoc/config.toml` (saved via `fintoc login`)
 
 ```bash
-fintoc login                                        # Interactive login
+fintoc login                                         # Interactive login
 fintoc login --api-key sk_test_...                   # Non-interactive login
 fintoc payment_intents list --api-key sk_test_...    # One-off override
 fintoc config show                                   # Show active configuration
@@ -175,3 +175,7 @@ fintoc v2 transfers list --help
 ## Feedback
 
 If you have any feedback, [open an issue](https://github.com/fintoc-com/fintoc-cli/issues).
+
+## Contributing
+
+See [Developing the Fintoc CLI](../../wiki/developing-the-fintoc-cli) for more info on how to make contributions to this project.


### PR DESCRIPTION
## Contexto

Estaba difícil cachar cómo desarrollar local al proyecto.

## Que hay de nuevo?

Agregué una página en la wiki con las instrucciones para casi todo lo que tiene que ver con desarrollo local, y agregué una sección al `README.md` apuntando a dicha wiki.
