### PR TITLE
[ONB-1950] Agregar LICENSE y cambiar a BSD-3-Clause

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,27 @@
+Copyright © 2026, [Fintoc](https://fintoc.com/).
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the author nor the names of contributors may be used to
+  endorse or promote products derived from this software without specific prior
+  written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -179,3 +179,7 @@ If you have any feedback, [open an issue](https://github.com/fintoc-com/fintoc-c
 ## Contributing
 
 See [Developing the Fintoc CLI](../../wiki/developing-the-fintoc-cli) for more info on how to make contributions to this project.
+
+## License
+
+[BSD-3-Clause](LICENSE.md)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "type": "git",
     "url": "https://github.com/fintoc-com/fintoc-cli"
   },
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "dependencies": {
     "@inquirer/prompts": "^8.4.2",
     "commander": "^14.0.3",


### PR DESCRIPTION
## Contexto

El repo es público y está publicado en npm como `@fintoc/cli`, pero no tiene archivo `LICENSE` (solo el campo `license` en `package.json`). Además, estábamos declarando `MIT` mientras que el SDK (`fintoc-com/fintoc-node`) está bajo `BSD-3-Clause`, lo que genera inconsistencia entre nuestros packages públicos.

## Que hay de nuevo?

- [x] `LICENSE.md` con BSD-3-Clause siguiendo la convención del SDK
- [x] `license` en `package.json` cambiado de `MIT` a `BSD-3-Clause`
- [x] Sección `License` en el README con link al `LICENSE.md`