### PR TITLE
[ONB-1971] Validate webhooks forward URL

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -94,6 +94,12 @@ describe('help consistency', () => {
       expect(exitCode).toBe(1)
       expect(stderr).toContain('Events must be a comma-separated list of non-empty strings')
     })
+
+    test('validates listen forward URL before running the command', () => {
+      const { stderr, exitCode } = run(['webhooks', 'listen', '--forward-to', 'not-a-url'], true)
+      expect(exitCode).toBe(1)
+      expect(stderr).toContain('Forward URL must be a valid URL')
+    })
   })
 
   describe('when operation --help is shown', () => {

--- a/src/commands/webhooks.ts
+++ b/src/commands/webhooks.ts
@@ -1,5 +1,6 @@
 import type { Command } from 'commander'
 import { InvalidArgumentError } from 'commander'
+import * as z from 'zod/mini'
 import { listenToRelay } from '../lib/action-cable.js'
 import { resolveAuth } from '../lib/auth.js'
 import { addDefaultAction } from '../lib/commands.js'
@@ -28,6 +29,16 @@ const parseEvents = (value: string) => {
   return events
 }
 
+const parseForwardTo = (value: string) => {
+  const result = z.url().safeParse(value)
+
+  if (!result.success) {
+    throw new InvalidArgumentError('Forward URL must be a valid URL')
+  }
+
+  return result.data
+}
+
 export const webhooksCommand = (program: Command) => {
   const cmd = program.command('webhooks').description('Listen for webhook events')
   cmd.configureHelp({ showGlobalOptions: true })
@@ -36,7 +47,7 @@ export const webhooksCommand = (program: Command) => {
   cmd
     .command('listen')
     .description('Listen for webhook events in real time')
-    .option('--forward-to <url>', 'Forward webhook events to a URL')
+    .option('--forward-to <url>', 'Forward webhook events to a URL', parseForwardTo)
     .option(
       '--events <events>',
       'Comma-separated list of webhook events to listen for',


### PR DESCRIPTION
## Contexto

Se podía pasar cualquier string en el `--forward-url`

## Que hay de nuevo?

Ahora solamente se puede pasar una URL válida

## Tests

Unitarios y pruebas locales.
