### PR TITLE
release: v0.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fintoc/cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fintoc/cli",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@inquirer/prompts": "^8.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fintoc/cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Fintoc CLI — manage your Fintoc resources from the terminal",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Description

Recovery del run de Release. El workflow falló en `release/finalize` porque la App `fin-releases` no estaba en el bypass del ruleset "Protect main", solo la había agregado en el branch protection clásico, pero el ruleset es un sistema aparte. 

Resultado del run:
- `@fintoc/cli@0.2.2` publicado en npm ✓
- Tag `v0.2.2` en remote (apuntando a este commit huérfano) ✓
- Commit del bump no llegó a `main` ❌
- Sin GitHub Release entry ❌

Este PR sube el commit huérfano a `main`. Después hay que crear el Release entry a mano:

```
gh release create v0.2.2 --target main --notes ""
```

Eso dispara automáticamente `update-homebrew.yml` y la fórmula de homebrew queda en 0.2.2.

Ya agregué `fin-releases` al ruleset bypass.

## Requirements

None — el commit ya existe en remote bajo el tag.

## Additional changes

None.