### PR TITLE
[ONB-2036] Habilitar comando en la cli para enviar eventos de prueba

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@inquirer/prompts": "^8.4.2",
         "commander": "^14.0.3",
-        "fintoc": "^1.19.0",
+        "fintoc": "^1.20.0",
         "smol-toml": "^1.6.1",
         "ws": "^8.20.0",
         "zod": "^4.4.3"
@@ -4450,9 +4450,9 @@
       }
     },
     "node_modules/fintoc": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/fintoc/-/fintoc-1.19.0.tgz",
-      "integrity": "sha512-0GG8Pe4pDoSTjcaqUrG8gak7/2hJsL2h8XKNtP3BkOWhBn7vqR+AbTm0ThIcM7qTKI2AyDPtQa0OU9FNTmmI1A==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/fintoc/-/fintoc-1.20.0.tgz",
+      "integrity": "sha512-mMb5EaabW8jI74Zn05mEFpXKtZT4wMk08aYX0vGdLh0ndtubd1hvOls9NE0WLyob+ehJE+9Bfib78g4XmJ2RJA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/node": "^22.15.18",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@inquirer/prompts": "^8.4.2",
     "commander": "^14.0.3",
-    "fintoc": "^1.19.0",
+    "fintoc": "^1.20.0",
     "smol-toml": "^1.6.1",
     "ws": "^8.20.0",
     "zod": "^4.4.3"

--- a/src/resources/__tests__/factory.test.ts
+++ b/src/resources/__tests__/factory.test.ts
@@ -40,6 +40,7 @@ const mockManager = {
   get: vi.fn(),
   list: vi.fn(),
   delete: vi.fn(),
+  test: vi.fn(),
 }
 
 const mockClient = {
@@ -760,6 +761,64 @@ describe('factory', () => {
 
         Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
       })
+    })
+  })
+
+  describe('test command', () => {
+    const testResourceWithTest: ResourceDef = {
+      name: 'webhook_endpoints',
+      displayName: 'webhook endpoint',
+      cliCommand: 'webhook_endpoints',
+      sdkMethod: 'paymentIntents',
+      sdkNamespace: 'v1',
+      verbs: ['test'],
+      priorityColumns: ['id'],
+      testFlags: [
+        { name: 'type', type: 'string', required: true, description: 'Event type to test' },
+      ],
+    }
+
+    test('calls SDK test with id and parsed flags', async () => {
+      const mockResult = { serialize: () => ({ id: 'we_123', status: 'ok' }) }
+      mockManager.test.mockResolvedValue(mockResult)
+
+      const program = createProgram(testResourceWithTest)
+      await program.parseAsync(
+        ['webhook_endpoints', 'test', 'we_123', '--type', 'payment_intent.succeeded'],
+        { from: 'user' },
+      )
+
+      expect(mockManager.test).toHaveBeenCalledWith('we_123', { type: 'payment_intent.succeeded' })
+      expect(success).toHaveBeenCalledWith(expect.stringContaining('we_123'))
+      expect(printDetail).toHaveBeenCalledWith({ id: 'we_123', status: 'ok' })
+    })
+
+    test('exits with error when required flag is missing', async () => {
+      const exitSpy = mockProcessExit()
+
+      const program = createProgram(testResourceWithTest)
+      await expect(
+        program.parseAsync(['webhook_endpoints', 'test', 'we_123'], { from: 'user' }),
+      ).rejects.toThrow('process.exit')
+
+      expect(mockManager.test).not.toHaveBeenCalled()
+      expect(error).toHaveBeenCalledWith(expect.stringContaining('--type'))
+
+      exitSpy.mockRestore()
+    })
+
+    test('outputs JSON when --json flag is set', async () => {
+      const mockResult = { serialize: () => ({ id: 'we_123', status: 'ok' }) }
+      mockManager.test.mockResolvedValue(mockResult)
+
+      const program = createProgram(testResourceWithTest)
+      await program.parseAsync(
+        ['--json', 'webhook_endpoints', 'test', 'we_123', '--type', 'payment_intent.succeeded'],
+        { from: 'user' },
+      )
+
+      expect(printJson).toHaveBeenCalledWith({ id: 'we_123', status: 'ok' })
+      expect(success).not.toHaveBeenCalled()
     })
   })
 

--- a/src/resources/__tests__/registry.test.ts
+++ b/src/resources/__tests__/registry.test.ts
@@ -36,7 +36,7 @@ describe('resource registry', () => {
     })
 
     test('verbs are valid', () => {
-      const validVerbs = new Set(['create', 'get', 'list', 'delete', 'expire'])
+      const validVerbs = new Set(['create', 'get', 'list', 'delete', 'expire', 'test'])
       resources.forEach((resource) => {
         resource.verbs.forEach((verb) => {
           expect(validVerbs.has(verb)).toBe(true)
@@ -63,6 +63,9 @@ describe('resource registry', () => {
           expect(validTypes.has(flag.type)).toBe(true)
         }
         for (const flag of resource.getFlags ?? []) {
+          expect(validTypes.has(flag.type)).toBe(true)
+        }
+        for (const flag of resource.testFlags ?? []) {
           expect(validTypes.has(flag.type)).toBe(true)
         }
       }
@@ -161,6 +164,13 @@ describe('resource registry', () => {
       const webhooks = resources.find((r) => r.name === 'webhook_endpoints')!
       const eventsFlag = webhooks.createFlags!.find((f) => f.name === 'enabled-events')!
       expect(eventsFlag.type).toBe('string[]')
+    })
+
+    test('webhook_endpoints supports test verb with required type flag', () => {
+      const webhooks = resources.find((r) => r.name === 'webhook_endpoints')!
+      expect(webhooks.verbs).toContain('test')
+      const requiredTestFlags = webhooks.testFlags!.filter((f) => f.required).map((f) => f.name)
+      expect(requiredTestFlags).toEqual(['type'])
     })
 
     test('account_verifications requires account-number and needs JWS', () => {

--- a/src/resources/factory.ts
+++ b/src/resources/factory.ts
@@ -425,12 +425,51 @@ const registerExpire = (parent: Command, resource: ResourceDef) => {
   })
 }
 
+const registerTest = (parent: Command, resource: ResourceDef) => {
+  const cmd = parent
+    .command('test <id>')
+    .description(`Send a test event to a ${resource.displayName}`)
+  addFlags(cmd, resource.testFlags ?? [])
+  cmd.action(async (id: string, _opts: unknown, actionCmd: Command) => {
+    const rootOpts = getRootOpts(actionCmd)
+    const flags = resource.testFlags ?? []
+
+    validateRequired(actionCmd, flags, resourceCliPath(resource), 'test')
+
+    try {
+      const args = collectSetOptions(actionCmd, flags)
+      const client = resolveClient(rootOpts, resource)
+      const manager = getManager(client, resource)
+
+      const result = await manager.test!(id, args)
+      const data = serialize(result)
+
+      if (rootOpts.json) {
+        printJson(data)
+      } else {
+        success(`Test event sent to ${resource.displayName} '${id}'`)
+        hint('')
+        printDetail(data)
+      }
+    } catch (err) {
+      handleError(err, {
+        cliPath: resourceCliPath(resource),
+        verb: 'test',
+        id,
+        json: rootOpts.json,
+        availableVerbs: resource.verbs,
+      })
+    }
+  })
+}
+
 const verbRegistrars = {
   create: registerCreate,
   get: registerGet,
   list: registerList,
   delete: registerDelete,
   expire: registerExpire,
+  test: registerTest,
 } satisfies Record<string, (parent: Command, resource: ResourceDef) => void>
 
 export const registerResourceCommands = (program: Command, resourceDefs: ResourceDef[]) => {

--- a/src/resources/registry.ts
+++ b/src/resources/registry.ts
@@ -137,7 +137,7 @@ export const resources: ResourceDef[] = [
     cliCommand: 'webhook_endpoints',
     sdkMethod: 'webhookEndpoints',
     sdkNamespace: 'v1',
-    verbs: ['create', 'get', 'list', 'delete'],
+    verbs: ['create', 'get', 'list', 'delete', 'test'],
     priorityColumns: ['id', 'name', 'url', 'status', 'created_at'],
     createFlags: [
       {
@@ -155,6 +155,14 @@ export const resources: ResourceDef[] = [
       { name: 'description', type: 'string', description: 'Description of the webhook endpoint' },
     ],
     listFlags: [],
+    testFlags: [
+      {
+        name: 'type',
+        type: 'string',
+        required: true,
+        description: 'Event type to test (e.g., payment_intent.succeeded)',
+      },
+    ],
   },
   {
     name: 'charges',

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ export type FintocConfig = {
   color?: boolean
 }
 
-export type Verb = 'create' | 'get' | 'list' | 'delete' | 'expire'
+export type Verb = 'create' | 'get' | 'list' | 'delete' | 'expire' | 'test'
 
 export type FlagType = 'string' | 'integer' | 'boolean' | 'string[]'
 
@@ -28,6 +28,7 @@ export type ResourceDef = {
   createFlags?: FlagDef[]
   listFlags?: FlagDef[]
   getFlags?: FlagDef[]
+  testFlags?: FlagDef[]
   getArg?: { name: string; description: string }
 }
 
@@ -37,6 +38,7 @@ export type SdkManager = {
   list?: (params: Record<string, unknown>) => Promise<unknown>
   delete?: (id: string) => Promise<unknown>
   expire?: (id: string) => Promise<unknown>
+  test?: (id: string, args: Record<string, unknown>) => Promise<unknown>
 }
 
 export type Serializable = {


### PR DESCRIPTION
## Contexto

Se habilitó un nuevo endpoint para enviar eventos de prueba

## Que hay de nuevo?
¿Qué?

- [x] Comando `fintoc webhook_endpoints test`

## Tests
¿Como nos aseguramos de que esto funciona?

- [x] Tests unitarios
- [x] Tests local (ver demo)

## Demo
<img width="896" height="389" alt="image" src="https://github.com/user-attachments/assets/d025a7dc-7ef8-4e35-a57a-17aaca3725f1" />

<img width="677" height="817" alt="image" src="https://github.com/user-attachments/assets/de0bfbc6-51cd-40c6-a793-da7bdee91b06" />
