### PR TITLE
[ONB-2059] Add browser login library

### DIFF
--- a/src/lib/__tests__/browser-login.test.ts
+++ b/src/lib/__tests__/browser-login.test.ts
@@ -1,0 +1,317 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import {
+  BrowserLoginError,
+  buildAuthorizeUrl,
+  parseCallback,
+  startBrowserLogin,
+} from '../browser-login.js'
+import { DASHBOARD_ORIGIN } from '../constants.js'
+
+vi.mock('../browser.js', () => ({
+  openInBrowser: vi.fn(async () => {}),
+}))
+
+type RunOptions = {
+  mode?: 'test' | 'live'
+  timeoutMs?: number
+}
+
+const runWithCallback = async (
+  options: RunOptions,
+  request: (callbackUrl: string, state: string) => Promise<Response>,
+) => {
+  const session = await startBrowserLogin({
+    mode: options.mode ?? 'test',
+    timeoutMs: options.timeoutMs,
+  })
+
+  const parsed = new URL(session.url)
+  const callbackUrl = parsed.searchParams.get('callback') ?? ''
+  const state = parsed.searchParams.get('state') ?? ''
+
+  setImmediate(() => {
+    request(callbackUrl, state).catch(() => {})
+  })
+
+  return session.result
+}
+
+const postCallback = (url: string, body: unknown, headers: Record<string, string> = {}) =>
+  fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Origin: DASHBOARD_ORIGIN, ...headers },
+    body: JSON.stringify(body),
+  })
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('buildAuthorizeUrl', () => {
+  test('includes all required query params', () => {
+    const url = buildAuthorizeUrl({
+      mode: 'live',
+      state: 'abc123',
+      callback: 'http://127.0.0.1:5555/callback',
+      suggestedName: 'my-host-cli',
+    })
+
+    const parsed = new URL(url)
+    expect(parsed.origin + parsed.pathname).toBe('https://dashboard.fintoc.com/cli/authorize')
+    expect(parsed.searchParams.get('mode')).toBe('live')
+    expect(parsed.searchParams.get('state')).toBe('abc123')
+    expect(parsed.searchParams.get('callback')).toBe('http://127.0.0.1:5555/callback')
+    expect(parsed.searchParams.get('suggested_name')).toBe('my-host-cli')
+    expect(parsed.searchParams.get('suggested_expiration')).toBe('90d')
+  })
+})
+
+describe('parseCallback', () => {
+  const state = 'a'.repeat(64)
+  const otherState = 'b'.repeat(64)
+
+  describe('when body is not an object', () => {
+    test('returns invalid', () => {
+      expect(parseCallback(null, state, 'test')).toEqual({ kind: 'invalid' })
+      expect(parseCallback('foo', state, 'test')).toEqual({ kind: 'invalid' })
+    })
+  })
+
+  describe('when state does not match', () => {
+    test('returns invalid even with otherwise valid fields', () => {
+      expect(
+        parseCallback(
+          { state: otherState, secret: 'sk', organization_name: 'A', mode: 'test' },
+          state,
+          'test',
+        ),
+      ).toEqual({ kind: 'invalid' })
+    })
+  })
+
+  describe('when payload has an access_denied error', () => {
+    test('returns denied', () => {
+      expect(parseCallback({ state, error: 'access_denied' }, state, 'test')).toEqual({
+        kind: 'denied',
+      })
+    })
+  })
+
+  describe('when required fields are missing or wrong type', () => {
+    test('returns invalid', () => {
+      expect(parseCallback({ state, secret: 'sk', organization_name: 'A' }, state, 'test')).toEqual(
+        { kind: 'invalid' },
+      )
+      expect(
+        parseCallback({ state, secret: 1, organization_name: 'A', mode: 'test' }, state, 'test'),
+      ).toEqual({ kind: 'invalid' })
+    })
+  })
+
+  describe('when mode differs from expected', () => {
+    test('returns mismatch with the actual mode', () => {
+      expect(
+        parseCallback({ state, secret: 'sk', organization_name: 'A', mode: 'test' }, state, 'live'),
+      ).toEqual({ kind: 'mismatch', actual: 'test' })
+    })
+  })
+
+  describe('when payload is valid', () => {
+    test('returns ok with full result', () => {
+      expect(
+        parseCallback(
+          {
+            state,
+            secret: 'sk_test_abc',
+            organization_name: 'Acme',
+            mode: 'test',
+            key_name: 'my-cli',
+            expires_at: '2026-01-01',
+          },
+          state,
+          'test',
+        ),
+      ).toEqual({
+        kind: 'ok',
+        result: {
+          secret: 'sk_test_abc',
+          organizationName: 'Acme',
+          mode: 'test',
+          keyName: 'my-cli',
+          expiresAt: '2026-01-01',
+        },
+      })
+    })
+
+    test('leaves keyName and expiresAt undefined when omitted', () => {
+      const outcome = parseCallback(
+        { state, secret: 'sk', organization_name: 'A', mode: 'test' },
+        state,
+        'test',
+      )
+      expect(outcome).toEqual({
+        kind: 'ok',
+        result: {
+          secret: 'sk',
+          organizationName: 'A',
+          mode: 'test',
+          keyName: undefined,
+          expiresAt: undefined,
+        },
+      })
+    })
+  })
+})
+
+describe('startBrowserLogin', () => {
+  describe('when the dashboard POSTs a valid test-mode payload', () => {
+    test('resolves with the authorize result', async () => {
+      const result = await runWithCallback({ mode: 'test' }, (callback, state) =>
+        postCallback(callback, {
+          state,
+          secret: 'sk_test_abc',
+          organization_name: 'Acme Corp',
+          mode: 'test',
+        }),
+      )
+
+      expect(result).toEqual({
+        secret: 'sk_test_abc',
+        organizationName: 'Acme Corp',
+        mode: 'test',
+        keyName: undefined,
+        expiresAt: undefined,
+      })
+    })
+  })
+
+  describe('when the dashboard POSTs a valid live-mode payload', () => {
+    test('includes key_name and expires_at', async () => {
+      const result = await runWithCallback({ mode: 'live' }, (callback, state) =>
+        postCallback(callback, {
+          state,
+          secret: 'sk_live_xyz',
+          organization_name: 'Acme Corp',
+          mode: 'live',
+          key_name: 'my-mac-cli',
+          expires_at: '2026-08-16T12:00:00Z',
+        }),
+      )
+
+      expect(result.keyName).toBe('my-mac-cli')
+      expect(result.expiresAt).toBe('2026-08-16T12:00:00Z')
+    })
+  })
+
+  describe('when the dashboard POSTs access_denied', () => {
+    test('rejects with reason denied', async () => {
+      const err = await runWithCallback({ mode: 'test' }, (callback, state) =>
+        postCallback(callback, { state, error: 'access_denied' }),
+      ).catch((e) => e)
+
+      expect(err).toBeInstanceOf(BrowserLoginError)
+      expect(err.reason).toBe('denied')
+    })
+  })
+
+  describe('when the state does not match', () => {
+    test('returns 400 and keeps waiting for a valid callback', async () => {
+      let badStatus = 0
+      const result = await runWithCallback({ mode: 'test' }, async (callback, state) => {
+        const badRes = await postCallback(callback, {
+          state: 'wrong-state',
+          secret: 'sk_test_abc',
+          organization_name: 'Acme',
+          mode: 'test',
+        })
+        badStatus = badRes.status
+        return postCallback(callback, {
+          state,
+          secret: 'sk_test_abc',
+          organization_name: 'Acme',
+          mode: 'test',
+        })
+      })
+
+      expect(badStatus).toBe(400)
+      expect(result.secret).toBe('sk_test_abc')
+    })
+  })
+
+  describe('when the Origin header is wrong', () => {
+    test('returns 403', async () => {
+      let badStatus = 0
+      await runWithCallback({ mode: 'test' }, async (callback, state) => {
+        const badRes = await postCallback(
+          callback,
+          { state, secret: 'sk', organization_name: 'A', mode: 'test' },
+          { Origin: 'https://evil.com' },
+        )
+        badStatus = badRes.status
+        return postCallback(callback, {
+          state,
+          secret: 'sk_test_ok',
+          organization_name: 'Acme',
+          mode: 'test',
+        })
+      })
+
+      expect(badStatus).toBe(403)
+    })
+  })
+
+  describe('when an OPTIONS preflight is received', () => {
+    test('responds 204 with CORS headers', async () => {
+      let preflight: Response | null = null
+      await runWithCallback({ mode: 'test' }, async (callback, state) => {
+        preflight = await fetch(callback, {
+          method: 'OPTIONS',
+          headers: {
+            Origin: DASHBOARD_ORIGIN,
+            'Access-Control-Request-Method': 'POST',
+            'Access-Control-Request-Headers': 'Content-Type',
+          },
+        })
+        return postCallback(callback, {
+          state,
+          secret: 'sk_test_ok',
+          organization_name: 'Acme',
+          mode: 'test',
+        })
+      })
+
+      expect(preflight!.status).toBe(204)
+      expect(preflight!.headers.get('access-control-allow-origin')).toBe(DASHBOARD_ORIGIN)
+      expect(preflight!.headers.get('access-control-allow-methods')).toContain('POST')
+    })
+  })
+
+  describe('when no callback arrives before timeout', () => {
+    test('rejects with reason timeout', async () => {
+      const session = await startBrowserLogin({
+        mode: 'test',
+        timeoutMs: 50,
+      })
+
+      const err = await session.result.catch((e) => e)
+      expect(err).toBeInstanceOf(BrowserLoginError)
+      expect(err.reason).toBe('timeout')
+    })
+  })
+
+  describe('when the response mode does not match the request', () => {
+    test('rejects with reason mismatch', async () => {
+      const err = await runWithCallback({ mode: 'live' }, (callback, state) =>
+        postCallback(callback, {
+          state,
+          secret: 'sk_test_x',
+          organization_name: 'Acme',
+          mode: 'test',
+        }),
+      ).catch((e) => e)
+
+      expect(err).toBeInstanceOf(BrowserLoginError)
+      expect(err.reason).toBe('mismatch')
+    })
+  })
+})

--- a/src/lib/browser-login.ts
+++ b/src/lib/browser-login.ts
@@ -1,0 +1,280 @@
+import type { IncomingMessage, Server, ServerResponse } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { Buffer } from 'node:buffer'
+import { randomBytes, timingSafeEqual } from 'node:crypto'
+import { createServer } from 'node:http'
+import { hostname } from 'node:os'
+import { z } from 'zod'
+import { openInBrowser } from './browser.js'
+import {
+  BROWSER_LOGIN_SUGGESTED_EXPIRATION,
+  BROWSER_LOGIN_TIMEOUT_MS,
+  DASHBOARD_AUTHORIZE_URL,
+  DASHBOARD_ORIGIN,
+} from './constants.js'
+
+export type BrowserLoginMode = 'test' | 'live'
+
+export type BrowserLoginResult = {
+  secret: string
+  organizationName: string
+  mode: BrowserLoginMode
+  keyName?: string
+  expiresAt?: string
+}
+
+export type BrowserLoginOptions = {
+  mode: BrowserLoginMode
+  timeoutMs?: number
+}
+
+export type BrowserLoginSession = {
+  url: string
+  result: Promise<BrowserLoginResult>
+}
+
+export type BrowserLoginErrorReason = 'denied' | 'timeout' | 'mismatch'
+
+export class BrowserLoginError extends Error {
+  reason: BrowserLoginErrorReason
+
+  constructor(reason: BrowserLoginErrorReason, message: string) {
+    super(message)
+    this.name = 'BrowserLoginError'
+    this.reason = reason
+  }
+}
+
+const MAX_BODY_BYTES = 64 * 1024
+
+const sanitizeHostname = (name: string) => {
+  const cleaned = name
+    .toLowerCase()
+    .replace(/\.local$/, '')
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  return cleaned || 'unknown'
+}
+
+const getSuggestedName = () => `${sanitizeHostname(hostname())}-cli`
+
+export const buildAuthorizeUrl = ({
+  mode,
+  state,
+  callback,
+  suggestedName,
+}: {
+  mode: BrowserLoginMode
+  state: string
+  callback: string
+  suggestedName: string
+}) => {
+  const url = new URL(DASHBOARD_AUTHORIZE_URL)
+  url.searchParams.set('mode', mode)
+  url.searchParams.set('state', state)
+  url.searchParams.set('callback', callback)
+  url.searchParams.set('suggested_name', suggestedName)
+  url.searchParams.set('suggested_expiration', BROWSER_LOGIN_SUGGESTED_EXPIRATION)
+  return url.toString()
+}
+
+const isValidState = (received: unknown, expected: string) => {
+  if (typeof received !== 'string' || received.length !== expected.length) {
+    return false
+  }
+  return timingSafeEqual(Buffer.from(received), Buffer.from(expected))
+}
+
+const readJsonBody = async (req: IncomingMessage): Promise<unknown> => {
+  const chunks: Buffer[] = []
+  let total = 0
+  for await (const chunk of req) {
+    const buf = chunk as Buffer
+    total += buf.length
+    if (total > MAX_BODY_BYTES) {
+      throw new Error('Body too large')
+    }
+    chunks.push(buf)
+  }
+  return JSON.parse(Buffer.concat(chunks).toString('utf-8'))
+}
+
+const setCorsHeaders = (res: ServerResponse) => {
+  res.setHeader('Access-Control-Allow-Origin', DASHBOARD_ORIGIN)
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
+  res.setHeader('Vary', 'Origin')
+}
+
+const respond = (res: ServerResponse, status: number) => {
+  res.writeHead(status)
+  res.end()
+}
+
+export type CallbackOutcome =
+  | { kind: 'invalid' }
+  | { kind: 'denied' }
+  | { kind: 'mismatch'; actual: string }
+  | { kind: 'ok'; result: BrowserLoginResult }
+
+const deniedPayloadSchema = z.object({
+  state: z.string(),
+  error: z.literal('access_denied'),
+})
+
+const successPayloadSchema = z.object({
+  state: z.string(),
+  secret: z.string(),
+  organization_name: z.string(),
+  mode: z.string(),
+  key_name: z.string().optional(),
+  expires_at: z.string().optional(),
+})
+
+const callbackPayloadSchema = z.union([deniedPayloadSchema, successPayloadSchema])
+
+export const parseCallback = (
+  body: unknown,
+  expectedState: string,
+  expectedMode: BrowserLoginMode,
+): CallbackOutcome => {
+  const parsed = callbackPayloadSchema.safeParse(body)
+  if (!parsed.success) {
+    return { kind: 'invalid' }
+  }
+
+  const data = parsed.data
+  if (!isValidState(data.state, expectedState)) {
+    return { kind: 'invalid' }
+  }
+
+  if ('error' in data) {
+    return { kind: 'denied' }
+  }
+
+  if (data.mode !== expectedMode) {
+    return { kind: 'mismatch', actual: data.mode }
+  }
+
+  return {
+    kind: 'ok',
+    result: {
+      secret: data.secret,
+      organizationName: data.organization_name,
+      mode: expectedMode,
+      keyName: data.key_name,
+      expiresAt: data.expires_at,
+    },
+  }
+}
+
+const startServer = (): Promise<{ server: Server; port: number; callbackUrl: string }> =>
+  new Promise((resolve, reject) => {
+    const server = createServer()
+    const onError = (err: Error) => reject(err)
+    server.once('error', onError)
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', onError)
+      const { port } = server.address() as AddressInfo
+      resolve({ server, port, callbackUrl: `http://127.0.0.1:${port}/callback` })
+    })
+  })
+
+export const startBrowserLogin = async (
+  options: BrowserLoginOptions,
+): Promise<BrowserLoginSession> => {
+  const timeoutMs = options.timeoutMs ?? BROWSER_LOGIN_TIMEOUT_MS
+  const state = randomBytes(32).toString('hex')
+  const { server, port, callbackUrl } = await startServer()
+  const url = buildAuthorizeUrl({
+    mode: options.mode,
+    state,
+    callback: callbackUrl,
+    suggestedName: getSuggestedName(),
+  })
+
+  const { promise: baseResult, resolve, reject } = Promise.withResolvers<BrowserLoginResult>()
+
+  const timeout = setTimeout(() => {
+    reject(new BrowserLoginError('timeout', 'Timed out waiting for authorization'))
+  }, timeoutMs)
+  timeout.unref()
+
+  const result = baseResult.finally(() => {
+    clearTimeout(timeout)
+    server.close()
+    setImmediate(() => server.closeAllConnections())
+  })
+
+  server.on('request', async (req: IncomingMessage, res: ServerResponse) => {
+    if (req.headers.host !== `127.0.0.1:${port}`) {
+      respond(res, 400)
+      return
+    }
+    let reqUrl: URL
+    try {
+      reqUrl = new URL(req.url ?? '/', `http://127.0.0.1:${port}`)
+    } catch {
+      respond(res, 400)
+      return
+    }
+    if (reqUrl.pathname !== '/callback') {
+      respond(res, 404)
+      return
+    }
+    if (req.headers.origin !== DASHBOARD_ORIGIN) {
+      respond(res, 403)
+      return
+    }
+
+    setCorsHeaders(res)
+
+    if (req.method === 'OPTIONS') {
+      respond(res, 204)
+      return
+    }
+
+    if (req.method !== 'POST') {
+      respond(res, 405)
+      return
+    }
+
+    let body: unknown
+    try {
+      body = await readJsonBody(req)
+    } catch {
+      respond(res, 400)
+      return
+    }
+
+    const outcome = parseCallback(body, state, options.mode)
+    switch (outcome.kind) {
+      case 'invalid':
+        respond(res, 400)
+        return
+      case 'denied':
+        respond(res, 204)
+        reject(new BrowserLoginError('denied', 'Authorization was denied in the browser'))
+        return
+      case 'mismatch':
+        respond(res, 204)
+        reject(
+          new BrowserLoginError(
+            'mismatch',
+            `Dashboard returned mode '${outcome.actual}' but expected '${options.mode}'`,
+          ),
+        )
+        return
+      case 'ok':
+        respond(res, 204)
+        resolve(outcome.result)
+        return
+      default:
+        outcome satisfies never
+    }
+  })
+
+  openInBrowser(url).catch(() => {})
+
+  return { url, result }
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -5,8 +5,12 @@ export const NPM_CHECK_TIMEOUT_MS = 10_000
 export const CONFIG_FILE_PERMISSIONS = 0o600
 export const CONFIG_DIR_PERMISSIONS = 0o700
 
-export const DASHBOARD_URL = 'https://dashboard.fintoc.com/'
-export const DASHBOARD_API_KEYS_URL = 'https://dashboard.fintoc.com/api-keys'
+export const DASHBOARD_ORIGIN = 'https://dashboard.fintoc.com'
+export const DASHBOARD_URL = `${DASHBOARD_ORIGIN}/`
+export const DASHBOARD_AUTHORIZE_URL = `${DASHBOARD_ORIGIN}/cli/authorize`
+export const DASHBOARD_API_KEYS_URL = `${DASHBOARD_ORIGIN}/api-keys`
+export const BROWSER_LOGIN_TIMEOUT_MS = 5 * 60 * 1000
+export const BROWSER_LOGIN_SUGGESTED_EXPIRATION = '90d'
 export const DOCS_TRANSFERS_URL = 'https://docs.fintoc.com/docs/transfers'
 export const DOCS_PAYMENT_INTENTS_URL =
   'https://docs.fintoc.com/reference/payment-intent-object-copy.md'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "Node16",
     "moduleResolution": "Node16",
-    "lib": ["ES2022"],
+    "lib": ["ES2024"],
     "types": ["node"],
     "outDir": "dist",
     "rootDir": "src",


### PR DESCRIPTION
## Contexto

Primer paso del flujo de login en el navegador. Este PR introduce el bloque base que va a consumir `fintoc login` para que el usuario pueda autenticarse desde el dashboard en vez de pegar manualmente la API key.

## Que hay de nuevo?

Una librería que orquesta el handshake completo entre la CLI y el dashboard.

- [x] Levanta un server efímero en `127.0.0.1` y abre la página de autorización del dashboard.
- [x] Resuelve con las credenciales cuando llega el callback, validando `state` contra CSRF y restringiendo CORS al origen del dashboard.
- [x] Soporta timeout configurable, con un `BrowserLoginError` tipado que expone `reason` para distinguir denegación, timeout y mismatch de modo.

## Tests

- [x] Tests unitarios de los helpers puros y del flujo end-to-end levantando el server real.

## Consideraciones

Apunta a `onb-2058-refactor-open-in-browser-helper` porque reutiliza el helper `openInBrowser`. El cableado a `fintoc login` y la persistencia de metadata de la key van en ONB-2057.

<sup>*Created with Claude Code `/create-pr` command*</sup>