### PR TITLE
chore: sync package version to 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fintoc/cli",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fintoc/cli",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@inquirer/prompts": "^8.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fintoc/cli",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Fintoc CLI — manage your Fintoc resources from the terminal",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Contexto

`v0.3.0` ya está en npm pero `main` quedó en `0.2.2`. Sin este sync, el próximo release vuelve a fallar en `verify-tag`.

## Que hay de nuevo?

- [x] Bump de `0.2.2` → `0.3.0` en `package.json` y `package-lock.json`

<sup>*Created with Claude Code `/create-pr` command*</sup>