### PR TITLE
release: v0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fintoc/cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fintoc/cli",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@inquirer/prompts": "^8.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fintoc/cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Fintoc CLI — manage your Fintoc resources from the terminal",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Contexto

`v0.4.0` ya está publicada en npm y el tag `v0.4.0` existe en remoto, pero el step `finalize` del workflow no pudo pushear el bump a main (la branch protection requiere PR + status checks, no se puede bypassear con la config actual).

Este PR sincroniza main con npm.

## Que hay de nuevo?

- [x] Bump de `0.3.0` → `0.4.0` en `package.json` y `package-lock.json`

## Consideraciones

Después del merge: `gh release create v0.4.0 --title v0.4.0 --notes "..."` para crear el GH Release (la action tampoco alcanzó a hacerlo).